### PR TITLE
Add Brevo Meditrust module integrating Brevo API

### DIFF
--- a/htdocs/custom/brevo-par-Meditrust/CHANGELOG.md
+++ b/htdocs/custom/brevo-par-Meditrust/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [1.0.0] - 2024-05-25
+### Added
+- Module Brevo par Meditrust initial release.
+- Configuration de la clé API avec validation instantanée.
+- Consultation des listes Brevo avec pagination.
+- Synchronisation des contacts Dolibarr vers Brevo et mémorisation en base.
+- Retrait d'un contact d'une liste Brevo depuis Dolibarr.
+- Tests unitaires pour l'API wrapper et la DAO de synchronisation.

--- a/htdocs/custom/brevo-par-Meditrust/README.md
+++ b/htdocs/custom/brevo-par-Meditrust/README.md
@@ -1,0 +1,32 @@
+# Module Brevo par Meditrust
+
+## Installation
+
+1. Copier le dossier `brevo-par-Meditrust` dans `htdocs/custom/` de votre instance Dolibarr 21.0.2.
+2. Connectez-vous en tant qu'administrateur et activez le module **Brevo** depuis la page des modules.
+3. Exécutez le script SQL `sql/llx_brevo_contactsync.sql` via l'interface Dolibarr (ou import SQL) pour créer la table de synchronisation si nécessaire.
+
+## Configuration
+
+1. Rendez-vous dans **Configuration > Modules/Applications > Brevo > Paramètres**.
+2. Renseignez votre clé API Brevo. La clé est validée immédiatement via l'API (`GET /account`).
+3. Après validation, la clé est stockée dans la constante `MAIN_BREVO_APIKEY`.
+
+## Utilisation
+
+- Consultez les listes Brevo synchronisées via le menu **Brevo > Listes**. La pagination Dolibarr permet de naviguer entre les listes.
+- Depuis la fiche d'un tiers ou d'un contact Dolibarr, utilisez le bloc **Intégration Brevo** pour :
+  - Pousser le contact dans une liste Brevo (`POST /contacts`).
+  - Visualiser les listes dans lesquelles le contact est inscrit.
+  - Retirer le contact d'une liste (`POST /contacts/lists/{id}/contacts/remove`).
+- Les synchronisations sont mémorisées dans la table `llx_brevo_contactsync` avec le statut et la date de dernière action.
+
+## Tests
+
+Un jeu de tests unitaires est fourni (wrapper API et DAO de synchronisation).
+
+```bash
+phpunit -c tests/phpunit.xml.dist
+```
+
+Les tests utilisent des stubs compatibles PHP 7.4 pour simuler l'environnement Dolibarr.

--- a/htdocs/custom/brevo-par-Meditrust/admin/setup.php
+++ b/htdocs/custom/brevo-par-Meditrust/admin/setup.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package   brevo-par-Meditrust
+ * @author    Meditrust
+ * @license   GPL-3.0-or-later
+ * @brief     Administration page to configure Brevo API key.
+ */
+
+require '../../../main.inc.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+dol_include_once('/brevo-par-Meditrust/class/brevoapi.class.php');
+
+global $langs, $user, $conf, $db;
+
+if (!$user->admin) {
+    accessforbidden();
+}
+
+$langs->load('admin');
+$langs->load('brevo@brevo-par-Meditrust');
+
+$action = GETPOST('action', 'alpha');
+
+if ($action === 'setapikey') {
+    if (!checkToken()) {
+        accessforbidden();
+    }
+
+    $apiKey = trim(GETPOST('BREVO_APIKEY', 'restricthtml'));
+    if ($apiKey === '') {
+        dolibarr_del_const($db, 'MAIN_BREVO_APIKEY', $conf->entity);
+        setEventMessages($langs->trans('BrevoApiKeyRemoved'), null, 'mesgs');
+    } else {
+        $api = new BrevoApi($db, $conf, $apiKey);
+        $response = $api->validateApiKey($apiKey);
+        if (!empty($response['success'])) {
+            dolibarr_set_const($db, 'MAIN_BREVO_APIKEY', $apiKey, 'chaine', 0, '', $conf->entity);
+            setEventMessages($langs->trans('BrevoApiKeySaved'), null, 'mesgs');
+        } else {
+            setEventMessages($response['error'], null, 'errors');
+        }
+    }
+}
+
+$helpUrl = '';
+llxHeader('', $langs->trans('BrevoSetupTitle'), $helpUrl);
+
+$linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php">'.$langs->trans('BackToModuleList').'</a>';
+print load_fiche_titre($langs->trans('BrevoSetupTitle'), $linkback, 'brevo@brevo-par-Meditrust');
+
+$token = newToken();
+?>
+<form action="<?php echo dol_escape_htmltag($_SERVER['PHP_SELF']); ?>" method="post" class="form-horizontal">
+    <input type="hidden" name="token" value="<?php echo $token; ?>" />
+    <input type="hidden" name="action" value="setapikey" />
+    <table class="noborder" width="100%">
+        <tr class="liste_titre">
+            <th><?php echo $langs->trans('Parameter'); ?></th>
+            <th><?php echo $langs->trans('Value'); ?></th>
+        </tr>
+        <tr>
+            <td class="fieldrequired"><?php echo $langs->trans('BrevoApiKeyLabel'); ?></td>
+            <td>
+                <input type="text" name="BREVO_APIKEY" size="60" value="<?php echo dol_escape_htmltag(isset($conf->global->MAIN_BREVO_APIKEY) ? $conf->global->MAIN_BREVO_APIKEY : ''); ?>" />
+            </td>
+        </tr>
+    </table>
+    <div class="center">
+        <input type="submit" class="button" value="<?php echo dol_escape_htmltag($langs->trans('Save')); ?>" />
+    </div>
+</form>
+<?php
+llxFooter();
+$db->close();

--- a/htdocs/custom/brevo-par-Meditrust/brevo/lists.php
+++ b/htdocs/custom/brevo-par-Meditrust/brevo/lists.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package   brevo-par-Meditrust
+ * @author    Meditrust
+ * @license   GPL-3.0-or-later
+ * @brief     Page to display Brevo contact lists.
+ */
+
+require '../../../main.inc.php';
+dol_include_once('/brevo-par-Meditrust/class/brevoapi.class.php');
+
+global $langs, $db, $conf, $user;
+
+if (empty($conf->brevo->enabled)) {
+    accessforbidden();
+}
+if (empty($user->rights->brevo->read)) {
+    accessforbidden();
+}
+
+$langs->load('brevo@brevo-par-Meditrust');
+$langs->load('other');
+
+$limit = GETPOST('limit', 'int');
+if ($limit <= 0) {
+    $limit = 25;
+}
+$page = GETPOST('page', 'int');
+if ($page < 0) {
+    $page = 0;
+}
+$offset = $page * $limit;
+
+$lists = array();
+$total = 0;
+$error = '';
+
+$apiKey = isset($conf->global->MAIN_BREVO_APIKEY) ? $conf->global->MAIN_BREVO_APIKEY : '';
+if ($apiKey === '') {
+    $error = $langs->trans('BrevoMissingApiKey');
+} else {
+    $api = new BrevoApi($db, $conf, $apiKey);
+    $response = $api->getLists($limit, $offset);
+    if (!empty($response['success'])) {
+        $lists = isset($response['data']['lists']) ? $response['data']['lists'] : array();
+        $total = isset($response['data']['count']) ? (int) $response['data']['count'] : count($lists);
+    } else {
+        $error = $response['error'];
+    }
+}
+
+$title = $langs->trans('BrevoListsTitle');
+llxHeader('', $title);
+
+print load_fiche_titre($title, '', 'brevo@brevo-par-Meditrust');
+
+if ($error !== '') {
+    print '<div class="error">'.dol_escape_htmltag($error).'</div>';
+} else {
+    print '<div class="div-table-responsive">';
+    print '<table class="noborder centpercent">';
+    print '<tr class="liste_titre">';
+    print '<th>'.$langs->trans('BrevoListId').'</th>';
+    print '<th>'.$langs->trans('Label').'</th>';
+    print '<th>'.$langs->trans('BrevoTotalContacts').'</th>';
+    print '</tr>';
+
+    if (empty($lists)) {
+        print '<tr><td colspan="3" class="opacitymedium">'.$langs->trans('NoDataFound').'</td></tr>';
+    } else {
+        foreach ($lists as $list) {
+            $listId = isset($list['id']) ? (int) $list['id'] : 0;
+            $listName = isset($list['name']) ? $list['name'] : '';
+            $listTotal = isset($list['totalSubscribers']) ? (int) $list['totalSubscribers'] : 0;
+            print '<tr>';
+            print '<td>'.$listId.'</td>';
+            print '<td>'.dol_escape_htmltag($listName).'</td>';
+            print '<td>'.$listTotal.'</td>';
+            print '</tr>';
+        }
+    }
+    print '</table>';
+    print '</div>';
+
+    $param = '&limit='.$limit;
+    print '<div class="pagination">';
+    if ($page > 0) {
+        print '<a class="butAction" href="'.dol_escape_htmltag($_SERVER['PHP_SELF']).'?page='.($page - 1).$param.'">'.$langs->trans('Previous').'</a> ';
+    }
+    if (($offset + $limit) < $total) {
+        print '<a class="butAction" href="'.dol_escape_htmltag($_SERVER['PHP_SELF']).'?page='.($page + 1).$param.'">'.$langs->trans('Next').'</a>';
+    }
+    print '</div>';
+}
+
+llxFooter();
+$db->close();

--- a/htdocs/custom/brevo-par-Meditrust/class/actions_brevo.class.php
+++ b/htdocs/custom/brevo-par-Meditrust/class/actions_brevo.class.php
@@ -1,0 +1,295 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package   brevo-par-Meditrust
+ * @author    Meditrust
+ * @license   GPL-3.0-or-later
+ * @brief     Hooks to integrate Brevo actions inside Dolibarr cards.
+ */
+
+require_once DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
+require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
+require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
+dol_include_once('/brevo-par-Meditrust/class/brevoapi.class.php');
+dol_include_once('/brevo-par-Meditrust/class/brevosync.class.php');
+
+/**
+ * Class ActionsBrevo
+ */
+class ActionsBrevo
+{
+    /** @var DoliDB */
+    public $db;
+
+    /**
+     * @param DoliDB $db Database handler
+     */
+    public function __construct($db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Handle POST actions
+     *
+     * @param array        $parameters Hook parameters
+     * @param CommonObject $object     Current object
+     * @param string       $action     Current action
+     * @param HookManager  $hookmanager Hook manager
+     * @return int
+     */
+    public function doActions($parameters, &$object, &$action, $hookmanager)
+    {
+        global $langs, $conf, $user;
+
+        if (empty($conf->brevo->enabled)) {
+            return 0;
+        }
+
+        $context = isset($parameters['context']) ? explode(':', $parameters['context']) : array();
+        if (!in_array('contactcard', $context) && !in_array('thirdpartycard', $context)) {
+            return 0;
+        }
+
+        $langs->load('brevo@brevo-par-Meditrust');
+
+        $brevoAction = GETPOST('brevo_action', 'alpha');
+        if ($brevoAction === '') {
+            return 0;
+        }
+
+        if (!checkToken()) {
+            setEventMessages($langs->trans('ErrorBadToken'), null, 'errors');
+            return -1;
+        }
+
+        $apiKey = !empty($conf->global->MAIN_BREVO_APIKEY) ? $conf->global->MAIN_BREVO_APIKEY : '';
+        if ($apiKey === '') {
+            setEventMessages($langs->trans('BrevoMissingApiKey'), null, 'errors');
+            return -1;
+        }
+
+        $api = new BrevoApi($this->db, $conf, $apiKey);
+        $sync = new BrevoSync($this->db);
+
+        $contactId = $this->getContactId($object, $context);
+        $thirdpartyId = $this->getThirdpartyId($object, $context);
+        $email = $this->getEmail($object, $context);
+
+        if ($email === '') {
+            setEventMessages($langs->trans('BrevoMissingEmail'), null, 'errors');
+            return -1;
+        }
+
+        if ($brevoAction === 'push') {
+            if (empty($user->rights->brevo->write)) {
+                setEventMessages($langs->trans('NotEnoughPermissions'), null, 'errors');
+                return -1;
+            }
+
+            $listId = GETPOST('brevo_list_id', 'int');
+            if ($listId <= 0) {
+                setEventMessages($langs->trans('BrevoSelectList'), null, 'errors');
+                return -1;
+            }
+
+            $attributes = $this->buildContactAttributes($object, $context);
+            $response = $api->upsertContact($email, $attributes, array($listId));
+            if (empty($response['success'])) {
+                setEventMessages($response['error'], null, 'errors');
+                return -1;
+            }
+
+            $sync->fk_socpeople = $contactId;
+            $sync->fk_societe = $thirdpartyId;
+            $sync->brevo_list_id = $listId;
+            $sync->brevo_contact_id = isset($response['data']['id']) ? (string) $response['data']['id'] : $email;
+            $sync->status = 'ok';
+
+            $res = $sync->create($user);
+            if ($res < 0) {
+                setEventMessages($sync->error, null, 'errors');
+                return -1;
+            }
+
+            setEventMessages($langs->trans('BrevoSyncSuccess'), null, 'mesgs');
+        } elseif ($brevoAction === 'remove') {
+            if (empty($user->rights->brevo->delete)) {
+                setEventMessages($langs->trans('NotEnoughPermissions'), null, 'errors');
+                return -1;
+            }
+
+            $listId = GETPOST('brevo_list_id', 'int');
+            if ($listId <= 0) {
+                setEventMessages($langs->trans('BrevoSelectList'), null, 'errors');
+                return -1;
+            }
+
+            $response = $api->removeContactsFromList($listId, array($email));
+            if (empty($response['success'])) {
+                setEventMessages($response['error'], null, 'errors');
+                return -1;
+            }
+
+            $res = $sync->markRemoved($contactId, $thirdpartyId, $listId);
+            if ($res < 0) {
+                setEventMessages($sync->error, null, 'errors');
+                return -1;
+            }
+
+            setEventMessages($langs->trans('BrevoRemovalSuccess'), null, 'mesgs');
+        }
+
+        return 0;
+    }
+
+    /**
+     * Print footer buttons
+     *
+     * @param array        $parameters Hook parameters
+     * @param CommonObject $object     Current object
+     * @param string       $action     Current action
+     * @param HookManager  $hookmanager Hook manager
+     * @return int
+     */
+    public function printCardFooter($parameters, &$object, &$action, $hookmanager)
+    {
+        global $langs, $conf, $user;
+
+        if (empty($conf->brevo->enabled)) {
+            return 0;
+        }
+
+        $context = isset($parameters['context']) ? explode(':', $parameters['context']) : array();
+        if (!in_array('contactcard', $context) && !in_array('thirdpartycard', $context)) {
+            return 0;
+        }
+
+        $langs->load('brevo@brevo-par-Meditrust');
+
+        $lists = array();
+        $listsError = '';
+        if (!empty($conf->global->MAIN_BREVO_APIKEY) && !empty($user->rights->brevo->read)) {
+            $api = new BrevoApi($this->db, $conf, $conf->global->MAIN_BREVO_APIKEY);
+            $response = $api->getLists(50, 0);
+            if (!empty($response['success']) && isset($response['data']['lists'])) {
+                $lists = $response['data']['lists'];
+            } elseif (!empty($response['error'])) {
+                $listsError = $response['error'];
+            }
+        }
+
+        $sync = new BrevoSync($this->db);
+        $syncEntries = $sync->fetchByContact($this->getContactId($object, $context), $this->getThirdpartyId($object, $context));
+
+        $form = new Form($this->db);
+        $parameters = array(
+            'object' => $object,
+            'context' => $context,
+            'lists' => $lists,
+            'listsError' => $listsError,
+            'syncEntries' => $syncEntries,
+            'user' => $user,
+            'form' => $form,
+        );
+
+        $hookmanager->resprints .= $this->renderTemplate('contact_brevo.tpl.php', $parameters);
+
+        return 0;
+    }
+
+    /**
+     * Render template
+     *
+     * @param string $template Template name
+     * @param array  $data     Data
+     * @return string
+     */
+    private function renderTemplate($template, array $data)
+    {
+        global $conf, $langs;
+
+        $templatePath = dol_buildpath('/brevo-par-Meditrust/tpl/'.$template);
+        if (!is_readable($templatePath)) {
+            return '';
+        }
+
+        extract($data);
+        ob_start();
+        include $templatePath;
+
+        return ob_get_clean();
+    }
+
+    /**
+     * @param CommonObject $object  Current object
+     * @param array        $context Context array
+     * @return int
+     */
+    private function getContactId($object, array $context)
+    {
+        if (in_array('contactcard', $context) && isset($object->id)) {
+            return (int) $object->id;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param CommonObject $object  Current object
+     * @param array        $context Context array
+     * @return int
+     */
+    private function getThirdpartyId($object, array $context)
+    {
+        if (in_array('thirdpartycard', $context) && isset($object->id)) {
+            return (int) $object->id;
+        }
+
+        if (in_array('contactcard', $context) && !empty($object->fk_soc)) {
+            return (int) $object->fk_soc;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param CommonObject $object  Current object
+     * @param array        $context Context array
+     * @return string
+     */
+    private function getEmail($object, array $context)
+    {
+        if (in_array('contactcard', $context) && !empty($object->email)) {
+            return $object->email;
+        }
+        if (in_array('thirdpartycard', $context) && !empty($object->email)) {
+            return $object->email;
+        }
+
+        return '';
+    }
+
+    /**
+     * Build contact attributes for Brevo
+     *
+     * @param CommonObject $object  Current object
+     * @param array        $context Context array
+     * @return array
+     */
+    private function buildContactAttributes($object, array $context)
+    {
+        $attributes = array();
+        if (in_array('contactcard', $context)) {
+            $attributes['FIRSTNAME'] = isset($object->firstname) ? $object->firstname : '';
+            $attributes['LASTNAME'] = isset($object->lastname) ? $object->lastname : '';
+        } elseif (in_array('thirdpartycard', $context)) {
+            $attributes['FIRSTNAME'] = '';
+            $attributes['LASTNAME'] = isset($object->name) ? $object->name : '';
+        }
+
+        return $attributes;
+    }
+}

--- a/htdocs/custom/brevo-par-Meditrust/class/brevoapi.class.php
+++ b/htdocs/custom/brevo-par-Meditrust/class/brevoapi.class.php
@@ -1,0 +1,204 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package   brevo-par-Meditrust
+ * @author    Meditrust
+ * @license   GPL-3.0-or-later
+ * @brief     Wrapper around Brevo REST API.
+ */
+
+require_once DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
+
+if (!function_exists('dol_buildpath')) {
+    require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+}
+
+/**
+ * Class BrevoApi
+ */
+class BrevoApi
+{
+    /** @var DoliDB */
+    private $db;
+
+    /** @var Conf */
+    private $conf;
+
+    /** @var string */
+    private $apiKey = '';
+
+    /**
+     * @param DoliDB $db   Database handler
+     * @param Conf   $conf Global configuration
+     * @param string $apiKey API key
+     */
+    public function __construct($db, $conf, $apiKey = '')
+    {
+        $this->db = $db;
+        $this->conf = $conf;
+        $this->apiKey = trim($apiKey);
+    }
+
+    /**
+     * Update API key at runtime
+     *
+     * @param string $apiKey API key
+     * @return void
+     */
+    public function setApiKey($apiKey)
+    {
+        $this->apiKey = trim((string) $apiKey);
+    }
+
+    /**
+     * Validate an API key by calling Brevo account endpoint.
+     *
+     * @param string $apiKey API key to validate
+     * @return array
+     */
+    public function validateApiKey($apiKey)
+    {
+        $previous = $this->apiKey;
+        $this->setApiKey($apiKey);
+        $response = $this->request('GET', '/account');
+        $this->setApiKey($previous);
+
+        return $response;
+    }
+
+    /**
+     * Retrieve Brevo contact lists
+     *
+     * @param int $limit  Number of results
+     * @param int $offset Offset
+     * @return array
+     */
+    public function getLists($limit = 50, $offset = 0)
+    {
+        $query = http_build_query(array('limit' => $limit, 'offset' => $offset));
+        $endpoint = '/contacts/lists?'.$query;
+
+        return $this->request('GET', $endpoint);
+    }
+
+    /**
+     * Create or update a contact in Brevo
+     *
+     * @param string $email      Contact email
+     * @param array  $attributes Attributes (FIRSTNAME, LASTNAME...)
+     * @param array  $listIds    Target list IDs
+     * @return array
+     */
+    public function upsertContact($email, array $attributes, array $listIds)
+    {
+        $payload = array(
+            'email' => $email,
+            'attributes' => $attributes,
+            'listIds' => array_map('intval', $listIds),
+            'updateEnabled' => true,
+        );
+
+        return $this->request('POST', '/contacts', $payload);
+    }
+
+    /**
+     * Remove a contact from a Brevo list
+     *
+     * @param int   $listId List ID
+     * @param array $emails Email addresses to remove
+     * @return array
+     */
+    public function removeContactsFromList($listId, array $emails)
+    {
+        $payload = array('emails' => array_values($emails));
+        $endpoint = '/contacts/lists/'.(int) $listId.'/contacts/remove';
+
+        return $this->request('POST', $endpoint, $payload);
+    }
+
+    /**
+     * Perform HTTP request against Brevo API.
+     *
+     * @param string     $method   HTTP method
+     * @param string     $endpoint API endpoint
+     * @param array|null $payload  Payload
+     * @return array
+     */
+    protected function request($method, $endpoint, $payload = null)
+    {
+        $url = 'https://api.brevo.com/v3'.$endpoint;
+        $headers = array(
+            'Accept: application/json',
+            'Content-Type: application/json',
+            'api-key: '.$this->apiKey,
+        );
+
+        if (empty($this->apiKey)) {
+            return $this->formatError('Missing API key');
+        }
+
+        $ch = curl_init($url);
+        if ($ch === false) {
+            return $this->formatError('Unable to initialize curl');
+        }
+
+        $method = strtoupper($method);
+        $payloadString = $payload ? json_encode($payload) : '';
+
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        if ($method === 'POST' || $method === 'PUT' || $method === 'PATCH') {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $payloadString);
+        }
+
+        $response = curl_exec($ch);
+        $error = curl_error($ch);
+        $info = curl_getinfo($ch);
+        curl_close($ch);
+
+        if ($response === false) {
+            return $this->formatError($error !== '' ? $error : 'Unknown curl error');
+        }
+
+        $decoded = json_decode($response, true);
+        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+            return $this->formatError('Invalid JSON response: '.json_last_error_msg());
+        }
+
+        $success = isset($info['http_code']) && $info['http_code'] >= 200 && $info['http_code'] < 300;
+        if (!$success) {
+            $message = isset($decoded['message']) ? $decoded['message'] : 'Unexpected HTTP status '.$info['http_code'];
+
+            return $this->formatError($message, $info['http_code'], $decoded);
+        }
+
+        return array(
+            'success' => true,
+            'http_code' => isset($info['http_code']) ? (int) $info['http_code'] : 200,
+            'data' => $decoded,
+        );
+    }
+
+    /**
+     * Format error response
+     *
+     * @param string     $message Error message
+     * @param int        $code    HTTP status code
+     * @param array|null $data    Additional data
+     * @return array
+     */
+    protected function formatError($message, $code = 0, $data = null)
+    {
+        dol_syslog(__METHOD__.' '.$message, LOG_WARNING);
+
+        return array(
+            'success' => false,
+            'http_code' => (int) $code,
+            'error' => $message,
+            'data' => $data,
+        );
+    }
+}

--- a/htdocs/custom/brevo-par-Meditrust/class/brevosync.class.php
+++ b/htdocs/custom/brevo-par-Meditrust/class/brevosync.class.php
@@ -1,0 +1,206 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package   brevo-par-Meditrust
+ * @author    Meditrust
+ * @license   GPL-3.0-or-later
+ * @brief     DAO to persist Brevo synchronisation entries.
+ */
+
+require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
+
+/**
+ * Class BrevoSync
+ */
+class BrevoSync extends CommonObject
+{
+    /** @var string */
+    public $element = 'brevo_contactsync';
+
+    /** @var string */
+    public $table_element = 'brevo_contactsync';
+
+    /** @var int */
+    public $id;
+
+    /** @var int */
+    public $entity = 1;
+
+    /** @var int */
+    public $fk_socpeople = 0;
+
+    /** @var int */
+    public $fk_societe = 0;
+
+    /** @var int */
+    public $brevo_list_id = 0;
+
+    /** @var string */
+    public $brevo_contact_id = '';
+
+    /** @var string */
+    public $date_sync = '';
+
+    /** @var string */
+    public $status = 'ok';
+
+    /**
+     * @param DoliDB $db Database handler
+     */
+    public function __construct($db)
+    {
+        $this->db = $db;
+        $this->ismultientitymanaged = 1;
+    }
+
+    /**
+     * Create synchronisation record
+     *
+     * @param User $user Current user
+     * @return int
+     */
+    public function create(User $user)
+    {
+        $now = dol_now();
+        $this->date_sync = $now;
+
+        global $conf;
+        $entity = isset($conf->entity) ? (int) $conf->entity : 1;
+
+        $this->db->begin();
+
+        $sqlSelect = 'SELECT rowid FROM '.MAIN_DB_PREFIX.$this->table_element;
+        $sqlSelect .= ' WHERE entity='.$entity;
+        $sqlSelect .= ' AND fk_socpeople='.(int) $this->fk_socpeople;
+        $sqlSelect .= ' AND fk_societe='.(int) $this->fk_societe;
+        $sqlSelect .= ' AND brevo_list_id='.(int) $this->brevo_list_id;
+
+        $resSelect = $this->db->query($sqlSelect);
+        if (!$resSelect) {
+            $this->db->rollback();
+            $this->error = $this->db->lasterror();
+            return -1;
+        }
+
+        $obj = $this->db->fetch_object($resSelect);
+        if ($obj) {
+            $update = 'UPDATE '.MAIN_DB_PREFIX.$this->table_element;
+            $update .= " SET status='".$this->db->escape($this->status)."',";
+            $update .= " brevo_contact_id='".$this->db->escape($this->brevo_contact_id)."',";
+            $update .= ' date_sync='.$this->db->idate($now);
+            $update .= ' WHERE rowid='.(int) $obj->rowid;
+
+            $res = $this->db->query($update);
+            if (!$res) {
+                $this->db->rollback();
+                $this->error = $this->db->lasterror();
+                return -1;
+            }
+
+            $this->id = (int) $obj->rowid;
+        } else {
+            $sql = 'INSERT INTO '.MAIN_DB_PREFIX.$this->table_element.' (entity, fk_socpeople, fk_societe, brevo_list_id, brevo_contact_id, date_sync, status) VALUES (';
+            $sql .= $entity.',';
+            $sql .= (int) $this->fk_socpeople.',';
+            $sql .= (int) $this->fk_societe.',';
+            $sql .= (int) $this->brevo_list_id.',';
+            $sql .= "'".$this->db->escape($this->brevo_contact_id)."',";
+            $sql .= $this->db->idate($now).',';
+            $sql .= "'".$this->db->escape($this->status)."')";
+
+            $res = $this->db->query($sql);
+            if (!$res) {
+                $this->db->rollback();
+                $this->error = $this->db->lasterror();
+                return -1;
+            }
+
+            $this->id = (int) $this->db->last_insert_id(MAIN_DB_PREFIX.$this->table_element);
+        }
+
+        $this->db->commit();
+
+        return $this->id;
+    }
+
+    /**
+     * Mark synchronisation line as removed
+     *
+     * @param int $contactId    Contact ID
+     * @param int $thirdpartyId Third party ID
+     * @param int $listId       Brevo list identifier
+     * @return int
+     */
+    public function markRemoved($contactId, $thirdpartyId, $listId)
+    {
+        $sql = 'UPDATE '.MAIN_DB_PREFIX.$this->table_element;
+        $sql .= " SET status='removed'";
+        $sql .= ', date_sync='.$this->db->idate(dol_now());
+        global $conf;
+        $entity = isset($conf->entity) ? (int) $conf->entity : 1;
+
+        $sql .= ' WHERE entity='.$entity;
+        $sql .= ' AND fk_socpeople='.(int) $contactId;
+        $sql .= ' AND brevo_list_id='.(int) $listId;
+        if ($thirdpartyId > 0) {
+            $sql .= ' AND fk_societe='.(int) $thirdpartyId;
+        }
+
+        $this->db->begin();
+        $res = $this->db->query($sql);
+        if (!$res) {
+            $this->db->rollback();
+            $this->error = $this->db->lasterror();
+            return -1;
+        }
+        $this->db->commit();
+
+        return 1;
+    }
+
+    /**
+     * Fetch synchronisation entries for a contact
+     *
+     * @param int $contactId    Contact ID
+     * @param int $thirdpartyId Third party ID
+     * @return array
+     */
+    public function fetchByContact($contactId, $thirdpartyId = 0)
+    {
+        global $conf;
+        $entity = isset($conf->entity) ? (int) $conf->entity : 1;
+
+        $sql = 'SELECT rowid, fk_socpeople, fk_societe, brevo_list_id, brevo_contact_id, date_sync, status';
+        $sql .= ' FROM '.MAIN_DB_PREFIX.$this->table_element;
+        $sql .= ' WHERE entity='.$entity;
+        $sql .= ' AND fk_socpeople='.(int) $contactId;
+        if ($thirdpartyId > 0) {
+            $sql .= ' AND fk_societe='.(int) $thirdpartyId;
+        }
+
+        $resql = $this->db->query($sql);
+        if (!$resql) {
+            $this->error = $this->db->lasterror();
+            return array();
+        }
+
+        $entries = array();
+        while ($obj = $this->db->fetch_object($resql)) {
+            $entries[] = array(
+                'rowid' => (int) $obj->rowid,
+                'fk_socpeople' => (int) $obj->fk_socpeople,
+                'fk_societe' => (int) $obj->fk_societe,
+                'brevo_list_id' => (int) $obj->brevo_list_id,
+                'brevo_contact_id' => $obj->brevo_contact_id,
+                'date_sync' => $this->db->jdate($obj->date_sync),
+                'status' => $obj->status,
+            );
+        }
+        $this->db->free($resql);
+
+        return $entries;
+    }
+}

--- a/htdocs/custom/brevo-par-Meditrust/core/modules/modBrevo.class.php
+++ b/htdocs/custom/brevo-par-Meditrust/core/modules/modBrevo.class.php
@@ -1,0 +1,134 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package   brevo-par-Meditrust
+ * @author    Meditrust
+ * @license   GPL-3.0-or-later
+ * @brief     Brevo module descriptor for Dolibarr 21.0.2
+ */
+
+require_once DOL_DOCUMENT_ROOT.'/core/modules/DolibarrModules.class.php';
+
+/**
+ * Class modBrevo
+ */
+class modBrevo extends DolibarrModules
+{
+    /**
+     * Constructor
+     *
+     * @param DoliDB $db Database handler
+     */
+    public function __construct($db)
+    {
+        $this->db = $db;
+
+        $this->numero = 104601; // Unique module ID
+        $this->rights_class = 'brevo';
+        $this->family = 'crm';
+        $this->module_position = '50';
+        $this->editor_name = 'Meditrust';
+        $this->editor_url = 'https://www.meditrust.fr';
+        $this->name = preg_replace('/^mod/i', '', get_class($this));
+        $this->description = 'Brevo integration for Dolibarr';
+        $this->version = '1.0.0';
+        $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
+        $this->special = 0;
+        $this->picto = 'brevo@brevo-par-Meditrust';
+
+        $this->dirs = array();
+
+        $this->config_page_url = array('setup.php@brevo-par-Meditrust');
+        $this->langfiles = array('brevo@brevo-par-Meditrust');
+
+        $this->module_parts = array(
+            'hooks' => array('thirdpartycard', 'contactcard')
+        );
+
+        $this->const = array();
+
+        $this->rights = array();
+        $r = 0;
+        $this->rights[$r][0] = 104601;
+        $this->rights[$r][1] = 'Read Brevo lists';
+        $this->rights[$r][2] = 'r';
+        $this->rights[$r][3] = 1;
+        $this->rights[$r][4] = 'read';
+        $r++;
+        $this->rights[$r][0] = 104602;
+        $this->rights[$r][1] = 'Synchronize contacts with Brevo';
+        $this->rights[$r][2] = 'w';
+        $this->rights[$r][3] = 0;
+        $this->rights[$r][4] = 'write';
+        $r++;
+        $this->rights[$r][0] = 104603;
+        $this->rights[$r][1] = 'Remove contacts from Brevo';
+        $this->rights[$r][2] = 'd';
+        $this->rights[$r][3] = 0;
+        $this->rights[$r][4] = 'delete';
+
+        $this->menu = array();
+
+        $this->menu[] = array(
+            'fk_menu' => 0,
+            'type' => 'top',
+            'titre' => 'Brevo',
+            'mainmenu' => 'brevo',
+            'leftmenu' => 'brevo_lists',
+            'url' => '/brevo-par-Meditrust/brevo/lists.php',
+            'langs' => 'brevo@brevo-par-Meditrust',
+            'position' => 100,
+            'enabled' => '\$conf->brevo->enabled && \$user->rights->brevo->read',
+            'perms' => '\$user->rights->brevo->read',
+            'target' => '',
+            'user' => 2
+        );
+
+        $this->menu[] = array(
+            'fk_menu' => 'fk_mainmenu=brevo',
+            'type' => 'left',
+            'titre' => 'BrevoLists',
+            'mainmenu' => 'brevo',
+            'leftmenu' => 'brevo_lists',
+            'url' => '/brevo-par-Meditrust/brevo/lists.php',
+            'langs' => 'brevo@brevo-par-Meditrust',
+            'position' => 101,
+            'enabled' => '\$conf->brevo->enabled && \$user->rights->brevo->read',
+            'perms' => '\$user->rights->brevo->read',
+            'target' => '',
+            'user' => 2
+        );
+    }
+
+    /**
+     * Initialize module
+     *
+     * @param string $options Options
+     * @return int
+     */
+    public function init($options = '')
+    {
+        $result = $this->_load_tables('/brevo-par-Meditrust/sql/');
+        if ($result < 0) {
+            return $result;
+        }
+
+        $sql = array();
+
+        return $this->_init($sql, $options);
+    }
+
+    /**
+     * Remove module
+     *
+     * @param string $options Options
+     * @return int
+     */
+    public function remove($options = '')
+    {
+        $sql = array();
+
+        return $this->_remove($sql, $options);
+    }
+}

--- a/htdocs/custom/brevo-par-Meditrust/langs/en_US/brevo.lang
+++ b/htdocs/custom/brevo-par-Meditrust/langs/en_US/brevo.lang
@@ -1,0 +1,26 @@
+# Brevo module English translations
+Brevo=Brevo
+BrevoLists=Brevo Lists
+BrevoSetupTitle=Brevo configuration
+BrevoApiKeyLabel=Brevo API key
+BrevoApiKeySaved=API key validated and saved.
+BrevoApiKeyRemoved=API key removed.
+BrevoMissingApiKey=Please provide a valid Brevo API key.
+BrevoMissingEmail=The contact has no email address.
+BrevoSelectList=Please choose a Brevo list.
+BrevoSyncSuccess=Contact successfully synchronised with Brevo.
+BrevoRemovalSuccess=Contact removed from the Brevo list.
+BrevoIntegrationTitle=Brevo integration
+BrevoNoListFound=No Brevo list available.
+BrevoSelectListLabel=Target list
+BrevoPushButton=Push to Brevo
+BrevoCurrentSubscriptions=Current Brevo subscriptions
+BrevoListId=List ID
+BrevoStatus=Status
+BrevoStatusOk=Active
+BrevoStatusRemoved=Removed
+BrevoRemoveButton=Remove from Brevo
+BrevoAlreadyRemoved=Already removed
+BrevoNoSyncHistory=No synchronisation recorded yet.
+BrevoListsTitle=Brevo contact lists
+BrevoTotalContacts=Subscribed contacts

--- a/htdocs/custom/brevo-par-Meditrust/langs/fr_FR/brevo.lang
+++ b/htdocs/custom/brevo-par-Meditrust/langs/fr_FR/brevo.lang
@@ -1,0 +1,26 @@
+# Brevo module French translations
+Brevo=Brevo
+BrevoLists=Listes Brevo
+BrevoSetupTitle=Configuration de Brevo
+BrevoApiKeyLabel=Clé API Brevo
+BrevoApiKeySaved=Clé API validée et enregistrée.
+BrevoApiKeyRemoved=Clé API supprimée.
+BrevoMissingApiKey=Veuillez renseigner une clé API Brevo valide.
+BrevoMissingEmail=Le contact ne possède pas d'adresse e-mail.
+BrevoSelectList=Veuillez sélectionner une liste Brevo.
+BrevoSyncSuccess=Le contact a été synchronisé avec Brevo.
+BrevoRemovalSuccess=Le contact a été retiré de la liste Brevo.
+BrevoIntegrationTitle=Intégration Brevo
+BrevoNoListFound=Aucune liste Brevo disponible.
+BrevoSelectListLabel=Liste cible
+BrevoPushButton=Pousser vers Brevo
+BrevoCurrentSubscriptions=Abonnements Brevo
+BrevoListId=ID Liste
+BrevoStatus=Statut
+BrevoStatusOk=Actif
+BrevoStatusRemoved=Supprimé
+BrevoRemoveButton=Retirer de Brevo
+BrevoAlreadyRemoved=Déjà retiré
+BrevoNoSyncHistory=Aucune synchronisation enregistrée.
+BrevoListsTitle=Listes de contacts Brevo
+BrevoTotalContacts=Contacts inscrits

--- a/htdocs/custom/brevo-par-Meditrust/sql/llx_brevo_contactsync.sql
+++ b/htdocs/custom/brevo-par-Meditrust/sql/llx_brevo_contactsync.sql
@@ -1,0 +1,20 @@
+-- ===================================================================
+-- Copyright (C) 2024 Meditrust
+-- Description: Brevo contact synchronisation table
+-- ===================================================================
+
+CREATE TABLE llx_brevo_contactsync (
+    rowid INT AUTO_INCREMENT PRIMARY KEY,
+    entity INT NOT NULL DEFAULT 1,
+    fk_socpeople INT NOT NULL DEFAULT 0,
+    fk_societe INT NOT NULL DEFAULT 0,
+    brevo_list_id INT NOT NULL,
+    brevo_contact_id VARCHAR(128) NOT NULL,
+    date_sync DATETIME NOT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'ok',
+    CONSTRAINT idx_brevo_contactsync_contact_list UNIQUE (entity, fk_socpeople, fk_societe, brevo_list_id)
+) ENGINE=innodb;
+
+CREATE INDEX idx_brevo_contactsync_socpeople ON llx_brevo_contactsync (fk_socpeople);
+CREATE INDEX idx_brevo_contactsync_societe ON llx_brevo_contactsync (fk_societe);
+CREATE INDEX idx_brevo_contactsync_status ON llx_brevo_contactsync (status);

--- a/htdocs/custom/brevo-par-Meditrust/tests/bootstrap.php
+++ b/htdocs/custom/brevo-par-Meditrust/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+$stubRoot = __DIR__.'/stubs';
+if (!defined('DOL_DOCUMENT_ROOT')) {
+    define('DOL_DOCUMENT_ROOT', $stubRoot);
+}
+if (!defined('DOL_URL_ROOT')) {
+    define('DOL_URL_ROOT', '');
+}
+
+spl_autoload_register(static function ($class) {
+    if ($class === 'DoliDB') {
+        eval('class DoliDB {}');
+    }
+});

--- a/htdocs/custom/brevo-par-Meditrust/tests/phpunit.xml.dist
+++ b/htdocs/custom/brevo-par-Meditrust/tests/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Brevo Module">
+            <directory suffix="Test.php">unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/htdocs/custom/brevo-par-Meditrust/tests/stubs/core/class/commonobject.class.php
+++ b/htdocs/custom/brevo-par-Meditrust/tests/stubs/core/class/commonobject.class.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+class CommonObject
+{
+    /** @var DoliDB */
+    public $db;
+
+    /** @var string */
+    public $error = '';
+}

--- a/htdocs/custom/brevo-par-Meditrust/tests/stubs/core/lib/date.lib.php
+++ b/htdocs/custom/brevo-par-Meditrust/tests/stubs/core/lib/date.lib.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+function dol_now()
+{
+    return time();
+}
+
+function dol_print_date($timestamp, $format)
+{
+    return date('Y-m-d H:i:s', (int) $timestamp);
+}

--- a/htdocs/custom/brevo-par-Meditrust/tests/stubs/core/lib/functions.lib.php
+++ b/htdocs/custom/brevo-par-Meditrust/tests/stubs/core/lib/functions.lib.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+if (!defined('LOG_DEBUG')) {
+    define('LOG_DEBUG', 7);
+}
+if (!defined('LOG_WARNING')) {
+    define('LOG_WARNING', 4);
+}
+
+function dol_syslog($message, $level = LOG_DEBUG)
+{
+    // no-op in unit tests
+}
+
+function dol_escape_htmltag($string)
+{
+    return htmlspecialchars((string) $string, ENT_QUOTES, 'UTF-8');
+}
+
+function dol_buildpath($path)
+{
+    $fullPath = DOL_DOCUMENT_ROOT.$path;
+    if (!file_exists($fullPath)) {
+        $moduleRoot = dirname(__DIR__, 4);
+        $alternative = $moduleRoot.$path;
+        if (file_exists($alternative)) {
+            return $alternative;
+        }
+    }
+
+    return $fullPath;
+}
+
+function newToken()
+{
+    return 'testtoken';
+}
+
+function checkToken()
+{
+    return true;
+}
+
+function setEventMessages($mesg, $mesgs = null, $style = 'mesgs')
+{
+    // no-op for tests
+}
+
+if (!function_exists('dol_include_once')) {
+    function dol_include_once($path)
+    {
+        $fullPath = DOL_DOCUMENT_ROOT.$path;
+        if (substr($fullPath, -4) !== '.php') {
+            $fullPath .= '.php';
+        }
+        if (!file_exists($fullPath)) {
+            $moduleRoot = dirname(__DIR__, 4);
+            $alt = $moduleRoot.$path;
+            if (substr($alt, -4) !== '.php') {
+                $alt .= '.php';
+            }
+            if (file_exists($alt)) {
+                require_once $alt;
+                return;
+            }
+        }
+        if (file_exists($fullPath)) {
+            require_once $fullPath;
+        }
+    }
+}

--- a/htdocs/custom/brevo-par-Meditrust/tests/stubs/user/class/user.class.php
+++ b/htdocs/custom/brevo-par-Meditrust/tests/stubs/user/class/user.class.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+class User
+{
+    /** @var int */
+    public $id = 0;
+}

--- a/htdocs/custom/brevo-par-Meditrust/tests/unit/BrevoApiTest.php
+++ b/htdocs/custom/brevo-par-Meditrust/tests/unit/BrevoApiTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+dol_include_once('/brevo-par-Meditrust/class/brevoapi.class.php');
+
+/**
+ * @covers BrevoApi
+ */
+class BrevoApiTest extends TestCase
+{
+    public function testGetListsWithoutApiKeyReturnsError(): void
+    {
+        $api = new BrevoApi(new DoliDB(), new stdClass(), '');
+        $response = $api->getLists();
+
+        $this->assertFalse($response['success']);
+        $this->assertSame('Missing API key', $response['error']);
+    }
+
+    public function testUpsertContactCastsListIdsToIntegers(): void
+    {
+        $api = new class(new DoliDB(), new stdClass(), 'abc') extends BrevoApi {
+            public $lastPayload;
+
+            protected function request($method, $endpoint, $payload = null)
+            {
+                $this->lastPayload = $payload;
+
+                return array('success' => true, 'http_code' => 200, 'data' => array());
+            }
+        };
+
+        $api->upsertContact('john@example.com', array('FIRSTNAME' => 'John'), array('12', 34));
+
+        $this->assertSame(array(12, 34), $api->lastPayload['listIds']);
+    }
+}

--- a/htdocs/custom/brevo-par-Meditrust/tests/unit/BrevoSyncTest.php
+++ b/htdocs/custom/brevo-par-Meditrust/tests/unit/BrevoSyncTest.php
@@ -1,0 +1,257 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+dol_include_once('/brevo-par-Meditrust/class/brevosync.class.php');
+
+if (!defined('MAIN_DB_PREFIX')) {
+    define('MAIN_DB_PREFIX', 'llx_');
+}
+
+if (!isset($GLOBALS['conf'])) {
+    $GLOBALS['conf'] = new stdClass();
+}
+$GLOBALS['conf']->entity = 1;
+
+class FakeResult
+{
+    /** @var array */
+    public $rows;
+
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+}
+
+class FakeDoliDB extends DoliDB
+{
+    public $data = array();
+    public $lastResult;
+    public $lasterror = '';
+    private $lastId = 0;
+
+    public function begin()
+    {
+    }
+
+    public function commit()
+    {
+    }
+
+    public function rollback()
+    {
+    }
+
+    public function escape($value)
+    {
+        return addslashes((string) $value);
+    }
+
+    public function idate($timestamp)
+    {
+        return "'".date('Y-m-d H:i:s', (int) $timestamp)."'";
+    }
+
+    public function last_insert_id($table)
+    {
+        return $this->lastId;
+    }
+
+    public function lasterror()
+    {
+        return $this->lasterror;
+    }
+
+    public function query($sql)
+    {
+        if (stripos($sql, 'SELECT rowid FROM') === 0) {
+            return $this->handleSelectRowId($sql);
+        }
+        if (stripos($sql, 'INSERT INTO') === 0) {
+            return $this->handleInsert($sql);
+        }
+        if (stripos($sql, 'UPDATE') === 0) {
+            return $this->handleUpdate($sql);
+        }
+        if (stripos($sql, 'SELECT rowid,') === 0) {
+            return $this->handleSelectList($sql);
+        }
+
+        $this->lasterror = 'Unsupported SQL';
+        return false;
+    }
+
+    private function handleSelectRowId($sql)
+    {
+        $conditions = $this->parseConditions($sql);
+        $matches = array();
+        foreach ($this->data as $row) {
+            if ($row['entity'] == $conditions['entity'] &&
+                $row['fk_socpeople'] == $conditions['fk_socpeople'] &&
+                $row['fk_societe'] == $conditions['fk_societe'] &&
+                $row['brevo_list_id'] == $conditions['brevo_list_id']) {
+                $matches[] = (object) array('rowid' => $row['rowid']);
+            }
+        }
+        $this->lastResult = new FakeResult($matches);
+
+        return $this->lastResult;
+    }
+
+    private function handleInsert($sql)
+    {
+        if (!preg_match('/VALUES \((.+)\)/', $sql, $matches)) {
+            $this->lasterror = 'Malformed INSERT';
+            return false;
+        }
+        $values = explode(',', $matches[1]);
+        $this->lastId++;
+        $this->data[] = array(
+            'rowid' => $this->lastId,
+            'entity' => (int) $values[0],
+            'fk_socpeople' => (int) $values[1],
+            'fk_societe' => (int) $values[2],
+            'brevo_list_id' => (int) $values[3],
+            'brevo_contact_id' => trim($values[4], "'"),
+            'date_sync' => strtotime(trim($values[5], "'")),
+            'status' => trim($values[6], "'"),
+        );
+
+        return true;
+    }
+
+    private function handleUpdate($sql)
+    {
+        $conditions = $this->parseConditions($sql);
+        foreach ($this->data as &$row) {
+            if (($row['rowid'] == $conditions['rowid']) || (
+                $row['entity'] == $conditions['entity'] &&
+                $row['fk_socpeople'] == $conditions['fk_socpeople'] &&
+                $row['brevo_list_id'] == $conditions['brevo_list_id'] &&
+                ($conditions['fk_societe'] === null || $row['fk_societe'] == $conditions['fk_societe'])
+            )) {
+                if (isset($conditions['status'])) {
+                    $row['status'] = $conditions['status'];
+                }
+                if (isset($conditions['brevo_contact_id'])) {
+                    $row['brevo_contact_id'] = $conditions['brevo_contact_id'];
+                }
+                if (isset($conditions['date_sync'])) {
+                    $row['date_sync'] = $conditions['date_sync'];
+                }
+            }
+        }
+        unset($row);
+
+        return true;
+    }
+
+    private function handleSelectList($sql)
+    {
+        $conditions = $this->parseConditions($sql);
+        $matches = array();
+        foreach ($this->data as $row) {
+            if ($row['entity'] == $conditions['entity'] &&
+                $row['fk_socpeople'] == $conditions['fk_socpeople'] &&
+                ($conditions['fk_societe'] === null || $row['fk_societe'] == $conditions['fk_societe'])) {
+                $matches[] = (object) array(
+                    'rowid' => $row['rowid'],
+                    'fk_socpeople' => $row['fk_socpeople'],
+                    'fk_societe' => $row['fk_societe'],
+                    'brevo_list_id' => $row['brevo_list_id'],
+                    'brevo_contact_id' => $row['brevo_contact_id'],
+                    'date_sync' => date('Y-m-d H:i:s', $row['date_sync']),
+                    'status' => $row['status'],
+                );
+            }
+        }
+        $this->lastResult = new FakeResult($matches);
+
+        return $this->lastResult;
+    }
+
+    private function parseConditions($sql)
+    {
+        $conditions = array(
+            'entity' => 1,
+            'fk_socpeople' => 0,
+            'fk_societe' => null,
+            'brevo_list_id' => 0,
+            'rowid' => null,
+            'status' => null,
+            'brevo_contact_id' => null,
+            'date_sync' => null,
+        );
+        if (preg_match('/entity=([0-9]+)/', $sql, $m)) {
+            $conditions['entity'] = (int) $m[1];
+        }
+        if (preg_match('/fk_socpeople=([0-9]+)/', $sql, $m)) {
+            $conditions['fk_socpeople'] = (int) $m[1];
+        }
+        if (preg_match('/fk_societe=([0-9]+)/', $sql, $m)) {
+            $conditions['fk_societe'] = (int) $m[1];
+        }
+        if (preg_match('/brevo_list_id=([0-9]+)/', $sql, $m)) {
+            $conditions['brevo_list_id'] = (int) $m[1];
+        }
+        if (preg_match('/rowid=([0-9]+)/', $sql, $m)) {
+            $conditions['rowid'] = (int) $m[1];
+        }
+        if (preg_match("/status='([^']+)'/", $sql, $m)) {
+            $conditions['status'] = $m[1];
+        }
+        if (preg_match("/brevo_contact_id='([^']+)'/", $sql, $m)) {
+            $conditions['brevo_contact_id'] = $m[1];
+        }
+        if (preg_match("/date_sync='([^']+)'/", $sql, $m)) {
+            $conditions['date_sync'] = strtotime($m[1]);
+        }
+
+        return $conditions;
+    }
+
+    public function fetch_object($result)
+    {
+        return array_shift($result->rows);
+    }
+
+    public function free($result)
+    {
+    }
+
+    public function jdate($date)
+    {
+        return strtotime($date);
+    }
+}
+
+/**
+ * @covers BrevoSync
+ */
+class BrevoSyncTest extends TestCase
+{
+    public function testCreateAndMarkRemoved(): void
+    {
+        $db = new FakeDoliDB();
+        $sync = new BrevoSync($db);
+        $user = new User();
+
+        $sync->fk_socpeople = 1;
+        $sync->fk_societe = 2;
+        $sync->brevo_list_id = 10;
+        $sync->brevo_contact_id = 'ABC';
+
+        $id = $sync->create($user);
+        $this->assertGreaterThan(0, $id);
+        $this->assertSame('ok', $db->data[0]['status']);
+
+        $entries = $sync->fetchByContact(1, 2);
+        $this->assertCount(1, $entries);
+        $this->assertSame(10, $entries[0]['brevo_list_id']);
+
+        $sync->markRemoved(1, 2, 10);
+        $this->assertSame('removed', $db->data[0]['status']);
+    }
+}

--- a/htdocs/custom/brevo-par-Meditrust/tpl/contact_brevo.tpl.php
+++ b/htdocs/custom/brevo-par-Meditrust/tpl/contact_brevo.tpl.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package   brevo-par-Meditrust
+ * @author    Meditrust
+ * @license   GPL-3.0-or-later
+ * @brief     Template displayed on contact/thirdparty cards for Brevo integration.
+ */
+
+if (!defined('DOL_DOCUMENT_ROOT')) {
+    exit;
+}
+
+/** @var Form $form */
+$form = isset($form) ? $form : null;
+$token = newToken();
+$cardUrl = $_SERVER['PHP_SELF'];
+if (in_array('thirdpartycard', $context)) {
+    $cardUrl .= '?socid='.(int) $object->id;
+} else {
+    $cardUrl .= '?id='.(int) $object->id;
+}
+?>
+<div class="card mt-3">
+    <div class="card-header">
+        <span class="fa fa-paper-plane"></span> <?php echo dol_escape_htmltag($langs->trans('BrevoIntegrationTitle')); ?>
+    </div>
+    <div class="card-body">
+        <?php if ($listsError !== '') { ?>
+            <div class="warning"><?php echo dol_escape_htmltag($listsError); ?></div>
+        <?php } elseif (empty($lists)) { ?>
+            <div class="opacitymedium"><?php echo dol_escape_htmltag($langs->trans('BrevoNoListFound')); ?></div>
+        <?php } else { ?>
+            <form method="post" action="<?php echo dol_escape_htmltag($cardUrl); ?>">
+                <input type="hidden" name="token" value="<?php echo $token; ?>" />
+                <input type="hidden" name="brevo_action" value="push" />
+                <div class="form-group">
+                    <label for="brevo_list_id" class="control-label"><?php echo dol_escape_htmltag($langs->trans('BrevoSelectListLabel')); ?></label>
+                    <select name="brevo_list_id" id="brevo_list_id" class="flat">
+                        <option value="0"><?php echo dol_escape_htmltag($langs->trans('Select')); ?></option>
+                        <?php foreach ($lists as $list) { ?>
+                            <option value="<?php echo (int) $list['id']; ?>"><?php echo dol_escape_htmltag($list['name']); ?></option>
+                        <?php } ?>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <button type="submit" class="butAction"><?php echo dol_escape_htmltag($langs->trans('BrevoPushButton')); ?></button>
+                </div>
+            </form>
+        <?php } ?>
+
+        <?php if (!empty($syncEntries)) { ?>
+            <h4><?php echo dol_escape_htmltag($langs->trans('BrevoCurrentSubscriptions')); ?></h4>
+            <table class="noborder centpercent">
+                <thead>
+                    <tr class="liste_titre">
+                        <th><?php echo dol_escape_htmltag($langs->trans('BrevoListId')); ?></th>
+                        <th><?php echo dol_escape_htmltag($langs->trans('BrevoStatus')); ?></th>
+                        <th><?php echo dol_escape_htmltag($langs->trans('Date')); ?></th>
+                        <th>&nbsp;</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($syncEntries as $entry) { ?>
+                        <tr>
+                            <td><?php echo (int) $entry['brevo_list_id']; ?></td>
+                            <td><?php echo dol_escape_htmltag($langs->trans('BrevoStatus'.ucfirst($entry['status']))); ?></td>
+                            <td><?php echo dol_escape_htmltag(dol_print_date($entry['date_sync'], 'dayhour')); ?></td>
+                            <td class="right">
+                                <?php if ($entry['status'] !== 'removed') { ?>
+                                    <form method="post" action="<?php echo dol_escape_htmltag($cardUrl); ?>">
+                                        <input type="hidden" name="token" value="<?php echo $token; ?>" />
+                                        <input type="hidden" name="brevo_action" value="remove" />
+                                        <input type="hidden" name="brevo_list_id" value="<?php echo (int) $entry['brevo_list_id']; ?>" />
+                                        <button type="submit" class="butActionDelete smallpaddingimp"><?php echo dol_escape_htmltag($langs->trans('BrevoRemoveButton')); ?></button>
+                                    </form>
+                                <?php } else { ?>
+                                    <span class="opacitymedium"><?php echo dol_escape_htmltag($langs->trans('BrevoAlreadyRemoved')); ?></span>
+                                <?php } ?>
+                            </td>
+                        </tr>
+                    <?php } ?>
+                </tbody>
+            </table>
+        <?php } else { ?>
+            <p class="opacitymedium"><?php echo dol_escape_htmltag($langs->trans('BrevoNoSyncHistory')); ?></p>
+        <?php } ?>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add the Brevo Meditrust module descriptor, admin setup and Brevo list browser
- implement API wrapper, sync DAO, hooks and contact templates for Brevo push/remove flows
- provide SQL install script, translations, documentation and unit tests with Dolibarr-compatible stubs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a69e6b288320944def8ba94946a8