### PR TITLE
Fix module packaging tree and document structure

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.2] - 2024-05-26
+### Fixed
+- Correction de l'arborescence du package pour respecter le standard Dolibarr (suppression du sous-répertoire redondant).
+- Mise à jour du guide d'arborescence dans la documentation utilisateur.
+
 ## [1.0.1] - 2024-05-25
 ### Changed
 - Renommage du module en **Brevo Integration** avec mise à jour des chemins Dolibarr et des constantes de configuration.

--- a/htdocs/custom/brevointegration/README.md
+++ b/htdocs/custom/brevointegration/README.md
@@ -6,6 +6,43 @@
 2. Connectez-vous en tant qu'administrateur et activez le module **Brevo Integration** depuis la page des modules.
 3. Exécutez le script SQL `sql/llx_brevo_contactsync.sql` via l'interface Dolibarr (ou import SQL) pour créer la table de synchronisation si nécessaire.
 
+## Arborescence du module
+
+Le zip distribué doit contenir **un unique dossier racine** `brevointegration/` avec les répertoires standards Dolibarr ci-dessous :
+
+```
+brevointegration/
+├── admin/
+│   └── setup.php
+├── class/
+│   ├── actions_brevointegration.class.php
+│   ├── brevoapi.class.php
+│   └── brevosync.class.php
+├── core/
+│   └── modules/
+│       └── modBrevoIntegration.class.php
+├── langs/
+│   ├── en_US/
+│   │   └── brevointegration.lang
+│   └── fr_FR/
+│       └── brevointegration.lang
+├── sql/
+│   └── llx_brevo_contactsync.sql
+├── tests/
+│   ├── bootstrap.php
+│   ├── phpunit.xml.dist
+│   └── unit/
+│       ├── BrevoApiTest.php
+│       └── BrevoSyncTest.php
+├── tpl/
+│   └── contact_brevointegration.tpl.php
+├── CHANGELOG.md
+├── README.md
+└── lists.php
+```
+
+Cette structure garantit la compatibilité avec l'assistant « Déployer module externe » de Dolibarr et évite les erreurs de copie lors de l'installation.
+
 ## Configuration
 
 1. Rendez-vous dans **Configuration > Modules/Applications > Brevo > Paramètres**.

--- a/htdocs/custom/brevointegration/lists.php
+++ b/htdocs/custom/brevointegration/lists.php
@@ -8,7 +8,40 @@ declare(strict_types=1);
  * @brief     Page to display Brevo contact lists.
  */
 
-require '../../../main.inc.php';
+// Load Dolibarr environment
+$res = 0;
+if (!$res && !empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+    $res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'].'/main.inc.php';
+}
+if (!$res) {
+    $tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+    $tmp2 = realpath(__FILE__);
+    $i = strlen($tmp) - 1;
+    $j = strlen($tmp2) - 1;
+    while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] === $tmp2[$j]) {
+        $i--;
+        $j--;
+    }
+    if ($i > 0 && file_exists(substr($tmp, 0, ($i + 1)).'/main.inc.php')) {
+        $res = @include substr($tmp, 0, ($i + 1)).'/main.inc.php';
+    }
+    if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1))).'/main.inc.php')) {
+        $res = @include dirname(substr($tmp, 0, ($i + 1))).'/main.inc.php';
+    }
+}
+if (!$res && file_exists('../main.inc.php')) {
+    $res = @include '../main.inc.php';
+}
+if (!$res && file_exists('../../main.inc.php')) {
+    $res = @include '../../main.inc.php';
+}
+if (!$res && file_exists('../../../main.inc.php')) {
+    $res = @include '../../../main.inc.php';
+}
+if (!$res) {
+    die('Include of main fails');
+}
+
 dol_include_once('/brevointegration/class/brevoapi.class.php');
 
 global $langs, $db, $conf, $user;


### PR DESCRIPTION
## Summary
- move the public lists page to the module root so the zip layout matches Dolibarr expectations
- load the Dolibarr environment using the recommended fallback strategy before including module classes
- document the expected module tree in the README and record the fix in the changelog

## Testing
- php -l htdocs/custom/brevointegration/lists.php

------
https://chatgpt.com/codex/tasks/task_e_68d7b20a9d80832095a3abf28aee4359