### PR TITLE
Document troubleshooting steps for deployment copy failure

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.3] - 2024-05-27
+### Fixed
+- Ajout d'une procédure de dépannage documentée pour éviter l'échec de copie lors du déploiement du module via l'assistant Dolibarr.
+
 ## [1.0.2] - 2024-05-26
 ### Fixed
 - Correction de l'arborescence du package pour respecter le standard Dolibarr (suppression du sous-répertoire redondant).

--- a/htdocs/custom/brevointegration/README.md
+++ b/htdocs/custom/brevointegration/README.md
@@ -6,6 +6,27 @@
 2. Connectez-vous en tant qu'administrateur et activez le module **Brevo Integration** depuis la page des modules.
 3. Exécutez le script SQL `sql/llx_brevo_contactsync.sql` via l'interface Dolibarr (ou import SQL) pour créer la table de synchronisation si nécessaire.
 
+### Déploiement via l'assistant Dolibarr
+
+Lors de l'utilisation du bouton **Déployer module externe** (upload ZIP), assurez-vous que :
+
+- Le zip contient un dossier racine unique `brevointegration/` sans niveau supplémentaire.
+- Le répertoire cible `htdocs/custom/brevointegration` n'existe pas ou est vide. Si une version précédente est encore présente, supprimez-la avec `rm -rf htdocs/custom/brevointegration` avant de relancer l'upload.
+- L'utilisateur PHP/FPM a les droits d'écriture sur `htdocs/custom/` et `documents/admin/temp/`.
+
+Si l'assistant affiche l'erreur :
+
+```
+Echec de copie du répertoire '/var/www/html/dolibarr/documents/admin/temp/brevointegration-x.y.z.dir/brevointegration' vers '/var/www/html/dolibarr/htdocs/custom/brevointegration'
+```
+
+1. Supprimez le répertoire cible `htdocs/custom/brevointegration` (ancien module ou copie partielle) puis réessayez.
+2. Videz les artefacts temporaires éventuels : `rm -rf documents/admin/temp/brevointegration-*`.
+3. Vérifiez les permissions : `chown -R www-data:www-data htdocs/custom documents/admin/temp` (adapté à votre distribution).
+4. Relancez enfin l'import du zip.
+
+Ces étapes évitent les conflits de copie lorsque Dolibarr tente d'écraser un module déjà présent.
+
 ## Arborescence du module
 
 Le zip distribué doit contenir **un unique dossier racine** `brevointegration/` avec les répertoires standards Dolibarr ci-dessous :

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -32,7 +32,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->editor_url = 'https://www.meditrust.fr';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.0.1';
+        $this->version = '1.0.3';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'brevointegration@brevointegration';


### PR DESCRIPTION
## Summary
- document deployment prerequisites and troubleshooting steps in the module README
- record the troubleshooting guidance in the changelog and bump the module version to 1.0.3

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b3ae58988320894dc60d4d75417c