### PR TITLE
Store Brevo list labels with sync entries

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.1] - 2024-05-29
+### Added
+- Stockage du libellé des listes Brevo synchronisées pour afficher un titre compréhensible dans les fiches contact et tiers.
+- Script SQL d'upgrade et tests unitaires adaptés au nouveau champ `brevo_list_label`.
+
 ## [1.2.0] - 2024-05-28
 ### Added
 - Configuration avancée des correspondances de champs Dolibarr/Brevo (champs standards et extrafields) avec interface d'administration dédiée.

--- a/htdocs/custom/brevointegration/class/actions_brevointegration.class.php
+++ b/htdocs/custom/brevointegration/class/actions_brevointegration.class.php
@@ -96,6 +96,12 @@ class ActionsBrevointegration
                 return -1;
             }
 
+            $listLabel = '';
+            $listResponse = $api->getList($listId);
+            if (!empty($listResponse['success']) && !empty($listResponse['data']['name'])) {
+                $listLabel = (string) $listResponse['data']['name'];
+            }
+
             $attributes = $this->buildContactAttributes($object, $context);
             $response = $api->upsertContact($email, $attributes, array($listId));
             if (empty($response['success'])) {
@@ -106,6 +112,7 @@ class ActionsBrevointegration
             $sync->fk_socpeople = $contactId;
             $sync->fk_societe = $thirdpartyId;
             $sync->brevo_list_id = $listId;
+            $sync->brevo_list_label = $listLabel;
             $sync->brevo_contact_id = isset($response['data']['id']) ? (string) $response['data']['id'] : $email;
             $sync->status = 'ok';
 

--- a/htdocs/custom/brevointegration/class/brevoapi.class.php
+++ b/htdocs/custom/brevointegration/class/brevoapi.class.php
@@ -89,6 +89,19 @@ class BrevoApi
     }
 
     /**
+     * Retrieve a single Brevo contact list
+     *
+     * @param int $listId List identifier
+     * @return array
+     */
+    public function getList($listId)
+    {
+        $endpoint = '/contacts/lists/'.(int) $listId;
+
+        return $this->request('GET', $endpoint);
+    }
+
+    /**
      * Create or update a contact in Brevo
      *
      * @param string $email      Contact email

--- a/htdocs/custom/brevointegration/class/brevosync.class.php
+++ b/htdocs/custom/brevointegration/class/brevosync.class.php
@@ -39,6 +39,9 @@ class BrevoSync extends CommonObject
     public $brevo_list_id = 0;
 
     /** @var string */
+    public $brevo_list_label = '';
+
+    /** @var string */
     public $brevo_contact_id = '';
 
     /** @var string */
@@ -89,8 +92,11 @@ class BrevoSync extends CommonObject
         if ($obj) {
             $update = 'UPDATE '.MAIN_DB_PREFIX.$this->table_element;
             $update .= " SET status='".$this->db->escape($this->status)."',";
-            $update .= " brevo_contact_id='".$this->db->escape($this->brevo_contact_id)."',";
-            $update .= ' date_sync='.$this->db->idate($now);
+            $update .= " brevo_contact_id='".$this->db->escape($this->brevo_contact_id)."'";
+            if ($this->brevo_list_label !== '') {
+                $update .= ", brevo_list_label='".$this->db->escape($this->brevo_list_label)."'";
+            }
+            $update .= ', date_sync='.$this->db->idate($now);
             $update .= ' WHERE rowid='.(int) $obj->rowid;
 
             $res = $this->db->query($update);
@@ -102,11 +108,12 @@ class BrevoSync extends CommonObject
 
             $this->id = (int) $obj->rowid;
         } else {
-            $sql = 'INSERT INTO '.MAIN_DB_PREFIX.$this->table_element.' (entity, fk_socpeople, fk_societe, brevo_list_id, brevo_contact_id, date_sync, status) VALUES (';
+            $sql = 'INSERT INTO '.MAIN_DB_PREFIX.$this->table_element.' (entity, fk_socpeople, fk_societe, brevo_list_id, brevo_list_label, brevo_contact_id, date_sync, status) VALUES (';
             $sql .= $entity.',';
             $sql .= (int) $this->fk_socpeople.',';
             $sql .= (int) $this->fk_societe.',';
             $sql .= (int) $this->brevo_list_id.',';
+            $sql .= "'".$this->db->escape($this->brevo_list_label)."',";
             $sql .= "'".$this->db->escape($this->brevo_contact_id)."',";
             $sql .= $this->db->idate($now).',';
             $sql .= "'".$this->db->escape($this->status)."')";
@@ -173,7 +180,7 @@ class BrevoSync extends CommonObject
         global $conf;
         $entity = isset($conf->entity) ? (int) $conf->entity : 1;
 
-        $sql = 'SELECT rowid, fk_socpeople, fk_societe, brevo_list_id, brevo_contact_id, date_sync, status';
+        $sql = 'SELECT rowid, fk_socpeople, fk_societe, brevo_list_id, brevo_list_label, brevo_contact_id, date_sync, status';
         $sql .= ' FROM '.MAIN_DB_PREFIX.$this->table_element;
         $sql .= ' WHERE entity='.$entity;
         $sql .= ' AND fk_socpeople='.(int) $contactId;
@@ -194,6 +201,7 @@ class BrevoSync extends CommonObject
                 'fk_socpeople' => (int) $obj->fk_socpeople,
                 'fk_societe' => (int) $obj->fk_societe,
                 'brevo_list_id' => (int) $obj->brevo_list_id,
+                'brevo_list_label' => isset($obj->brevo_list_label) ? $obj->brevo_list_label : '',
                 'brevo_contact_id' => $obj->brevo_contact_id,
                 'date_sync' => $this->db->jdate($obj->date_sync),
                 'status' => $obj->status,

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -32,7 +32,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->editor_url = 'https://www.meditrust.fr';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.1.0';
+        $this->version = '1.2.1';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'brevointegration@brevointegration';

--- a/htdocs/custom/brevointegration/langs/en_US/brevointegration.lang
+++ b/htdocs/custom/brevointegration/langs/en_US/brevointegration.lang
@@ -17,6 +17,7 @@ BrevoNoListFound=No Brevo list available.
 BrevoSelectListLabel=Target list
 BrevoPushButton=Push to Brevo
 BrevoCurrentSubscriptions=Current Brevo subscriptions
+BrevoListLabel=Brevo list
 BrevoListId=List ID
 BrevoStatus=Status
 BrevoStatusOk=Active

--- a/htdocs/custom/brevointegration/langs/fr_FR/brevointegration.lang
+++ b/htdocs/custom/brevointegration/langs/fr_FR/brevointegration.lang
@@ -17,6 +17,7 @@ BrevoNoListFound=Aucune liste Brevo disponible.
 BrevoSelectListLabel=Liste cible
 BrevoPushButton=Pousser vers Brevo
 BrevoCurrentSubscriptions=Abonnements Brevo
+BrevoListLabel=Liste Brevo
 BrevoListId=ID Liste
 BrevoStatus=Statut
 BrevoStatusOk=Actif

--- a/htdocs/custom/brevointegration/lists.php
+++ b/htdocs/custom/brevointegration/lists.php
@@ -96,7 +96,7 @@ if ($error !== '') {
     print '<table class="noborder centpercent">';
     print '<tr class="liste_titre">';
     print '<th>'.$langs->trans('BrevoListId').'</th>';
-    print '<th>'.$langs->trans('Label').'</th>';
+    print '<th>'.$langs->trans('BrevoListLabel').'</th>';
     print '<th>'.$langs->trans('BrevoTotalContacts').'</th>';
     print '</tr>';
 

--- a/htdocs/custom/brevointegration/sql/llx_brevo_contactsync.sql
+++ b/htdocs/custom/brevointegration/sql/llx_brevo_contactsync.sql
@@ -9,6 +9,7 @@ CREATE TABLE llx_brevo_contactsync (
     fk_socpeople INT NOT NULL DEFAULT 0,
     fk_societe INT NOT NULL DEFAULT 0,
     brevo_list_id INT NOT NULL,
+    brevo_list_label VARCHAR(255) NOT NULL DEFAULT '',
     brevo_contact_id VARCHAR(128) NOT NULL,
     date_sync DATETIME NOT NULL,
     status VARCHAR(16) NOT NULL DEFAULT 'ok',

--- a/htdocs/custom/brevointegration/sql/updates/1.2.0_to_1.2.1.sql
+++ b/htdocs/custom/brevointegration/sql/updates/1.2.0_to_1.2.1.sql
@@ -1,0 +1,6 @@
+-- ===================================================================
+-- Upgrade script from 1.2.0 to 1.2.1
+-- ===================================================================
+
+ALTER TABLE llx_brevo_contactsync
+    ADD COLUMN brevo_list_label VARCHAR(255) NOT NULL DEFAULT '' AFTER brevo_list_id;

--- a/htdocs/custom/brevointegration/tests/unit/BrevoApiTest.php
+++ b/htdocs/custom/brevointegration/tests/unit/BrevoApiTest.php
@@ -56,4 +56,22 @@ class BrevoApiTest extends TestCase
 
         $this->assertSame(array(12, 34), $api->lastPayload['listIds']);
     }
+
+    public function testGetListUsesExpectedEndpoint(): void
+    {
+        $api = new class(new DoliDB(), new stdClass(), 'abc', new NullBrevoLogService()) extends BrevoApi {
+            public $lastEndpoint;
+
+            protected function request($method, $endpoint, $payload = null)
+            {
+                $this->lastEndpoint = $endpoint;
+
+                return array('success' => true, 'http_code' => 200, 'data' => array());
+            }
+        };
+
+        $api->getList(42);
+
+        $this->assertSame('/contacts/lists/42', $api->lastEndpoint);
+    }
 }

--- a/htdocs/custom/brevointegration/tests/unit/BrevoSyncTest.php
+++ b/htdocs/custom/brevointegration/tests/unit/BrevoSyncTest.php
@@ -106,7 +106,7 @@ class FakeDoliDB extends DoliDB
             $this->lasterror = 'Malformed INSERT';
             return false;
         }
-        $values = explode(',', $matches[1]);
+        $values = str_getcsv($matches[1], ',', "'", '\\');
         $this->lastId++;
         $this->data[] = array(
             'rowid' => $this->lastId,
@@ -114,9 +114,10 @@ class FakeDoliDB extends DoliDB
             'fk_socpeople' => (int) $values[1],
             'fk_societe' => (int) $values[2],
             'brevo_list_id' => (int) $values[3],
-            'brevo_contact_id' => trim($values[4], "'"),
-            'date_sync' => strtotime(trim($values[5], "'")),
-            'status' => trim($values[6], "'"),
+            'brevo_list_label' => $values[4],
+            'brevo_contact_id' => $values[5],
+            'date_sync' => strtotime($values[6]),
+            'status' => $values[7],
         );
 
         return true;
@@ -137,6 +138,9 @@ class FakeDoliDB extends DoliDB
                 }
                 if (isset($conditions['brevo_contact_id'])) {
                     $row['brevo_contact_id'] = $conditions['brevo_contact_id'];
+                }
+                if (isset($conditions['brevo_list_label'])) {
+                    $row['brevo_list_label'] = $conditions['brevo_list_label'];
                 }
                 if (isset($conditions['date_sync'])) {
                     $row['date_sync'] = $conditions['date_sync'];
@@ -161,6 +165,7 @@ class FakeDoliDB extends DoliDB
                     'fk_socpeople' => $row['fk_socpeople'],
                     'fk_societe' => $row['fk_societe'],
                     'brevo_list_id' => $row['brevo_list_id'],
+                    'brevo_list_label' => $row['brevo_list_label'],
                     'brevo_contact_id' => $row['brevo_contact_id'],
                     'date_sync' => date('Y-m-d H:i:s', $row['date_sync']),
                     'status' => $row['status'],
@@ -179,6 +184,7 @@ class FakeDoliDB extends DoliDB
             'fk_socpeople' => 0,
             'fk_societe' => null,
             'brevo_list_id' => 0,
+            'brevo_list_label' => null,
             'rowid' => null,
             'status' => null,
             'brevo_contact_id' => null,
@@ -204,6 +210,9 @@ class FakeDoliDB extends DoliDB
         }
         if (preg_match("/brevo_contact_id='([^']+)'/", $sql, $m)) {
             $conditions['brevo_contact_id'] = $m[1];
+        }
+        if (preg_match("/brevo_list_label='([^']*)'/", $sql, $m)) {
+            $conditions['brevo_list_label'] = $m[1];
         }
         if (preg_match("/date_sync='([^']+)'/", $sql, $m)) {
             $conditions['date_sync'] = strtotime($m[1]);
@@ -241,6 +250,7 @@ class BrevoSyncTest extends TestCase
         $sync->fk_socpeople = 1;
         $sync->fk_societe = 2;
         $sync->brevo_list_id = 10;
+        $sync->brevo_list_label = 'Newsletter';
         $sync->brevo_contact_id = 'ABC';
 
         $id = $sync->create($user);
@@ -250,6 +260,14 @@ class BrevoSyncTest extends TestCase
         $entries = $sync->fetchByContact(1, 2);
         $this->assertCount(1, $entries);
         $this->assertSame(10, $entries[0]['brevo_list_id']);
+        $this->assertSame('Newsletter', $entries[0]['brevo_list_label']);
+
+        $sync->brevo_list_label = 'VIP Newsletter';
+        $sync->brevo_contact_id = 'DEF';
+        $sync->create($user);
+
+        $entries = $sync->fetchByContact(1, 2);
+        $this->assertSame('VIP Newsletter', $entries[0]['brevo_list_label']);
 
         $sync->markRemoved(1, 2, 10);
         $this->assertSame('removed', $db->data[0]['status']);

--- a/htdocs/custom/brevointegration/tpl/contact_brevointegration.tpl.php
+++ b/htdocs/custom/brevointegration/tpl/contact_brevointegration.tpl.php
@@ -55,7 +55,7 @@ if (in_array('thirdpartycard', $context)) {
             <table class="noborder centpercent">
                 <thead>
                     <tr class="liste_titre">
-                        <th><?php echo dol_escape_htmltag($langs->trans('BrevoListId')); ?></th>
+                        <th><?php echo dol_escape_htmltag($langs->trans('BrevoListLabel')); ?></th>
                         <th><?php echo dol_escape_htmltag($langs->trans('BrevoStatus')); ?></th>
                         <th><?php echo dol_escape_htmltag($langs->trans('Date')); ?></th>
                         <th>&nbsp;</th>
@@ -64,7 +64,14 @@ if (in_array('thirdpartycard', $context)) {
                 <tbody>
                     <?php foreach ($syncEntries as $entry) { ?>
                         <tr>
-                            <td><?php echo (int) $entry['brevo_list_id']; ?></td>
+                            <td>
+                                <?php if (!empty($entry['brevo_list_label'])) { ?>
+                                    <?php echo dol_escape_htmltag($entry['brevo_list_label']); ?>
+                                    <div class="opacitymedium"><?php echo dol_escape_htmltag($langs->trans('BrevoListId')); ?> : <?php echo (int) $entry['brevo_list_id']; ?></div>
+                                <?php } else { ?>
+                                    <?php echo (int) $entry['brevo_list_id']; ?>
+                                <?php } ?>
+                            </td>
                             <td><?php echo dol_escape_htmltag($langs->trans('BrevoStatus'.ucfirst($entry['status']))); ?></td>
                             <td><?php echo dol_escape_htmltag(dol_print_date($entry['date_sync'], 'dayhour')); ?></td>
                             <td class="right">


### PR DESCRIPTION
## Summary
- add the `brevo_list_label` column to Brevo sync records with an upgrade script and DAO support
- fetch list metadata from the Brevo API when pushing contacts and display the stored label instead of only the numeric id
- refresh translations, changelog, version, and unit tests to cover the new behaviour

## Testing
- phpunit -c phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d7c1db8c6483209c0fdc3bc7745e23