### PR TITLE
Use Brevo SVG icon for module descriptor

### DIFF
--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -35,7 +35,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->version = '1.2.1';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
-        $this->picto = 'brevointegration@brevointegration';
+        $this->picto = 'icon-picto-brevo@brevointegration';
 
         $this->dirs = array();
 


### PR DESCRIPTION
## Summary
- reference the icon-picto-brevo SVG file as the module picto so the Brevo module shows the right graphic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7dfea706083209a5e16f5328d3718