### PR TITLE
Fix BrevoIntegration SVG picto references

### DIFF
--- a/htdocs/custom/brevointegration/admin/logs.php
+++ b/htdocs/custom/brevointegration/admin/logs.php
@@ -98,7 +98,7 @@ if ($limit) {
 llxHeader('', $langs->trans('BrevoLogsTitle'));
 
 $linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php">'.$langs->trans('BackToModuleList').'</a>';
-print load_fiche_titre($langs->trans('BrevoLogsTitle'), $linkback, 'brevointegration@brevointegration');
+print load_fiche_titre($langs->trans('BrevoLogsTitle'), $linkback, 'icon-picto-brevo.svg@brevointegration');
 print '<p class="opacitymedium">'.$langs->trans('BrevoLogsIntro').'</p>';
 
 print '<form method="GET" action="'.dol_escape_htmltag($_SERVER['PHP_SELF']).'" class="filter">';

--- a/htdocs/custom/brevointegration/admin/setup.php
+++ b/htdocs/custom/brevointegration/admin/setup.php
@@ -113,7 +113,7 @@ $helpUrl = '';
 llxHeader('', $langs->trans('BrevoSetupTitle'), $helpUrl);
 
 $linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php">'.$langs->trans('BackToModuleList').'</a>';
-print load_fiche_titre($langs->trans('BrevoSetupTitle'), $linkback, 'brevointegration@brevointegration');
+print load_fiche_titre($langs->trans('BrevoSetupTitle'), $linkback, 'icon-picto-brevo.svg@brevointegration');
 
 $token = newToken();
 $mappingToken = newToken();

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -35,7 +35,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->version = '1.2.1';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
-        $this->picto = 'icon-picto-brevo@brevointegration';
+        $this->picto = 'icon-picto-brevo.svg@brevointegration';
 
         $this->dirs = array();
 
@@ -78,7 +78,7 @@ class modBrevoIntegration extends DolibarrModules
             'leftmenu' => 'brevointegration_lists',
             'url' => '/brevointegration/brevointegration/lists.php',
             'langs' => 'brevointegration@brevointegration',
-            'picto' => 'icon-picto-brevo@brevointegration',
+            'picto' => 'icon-picto-brevo.svg@brevointegration',
             'position' => 100,
             'enabled' => '\$conf->brevointegration->enabled && \$user->rights->brevointegration->read',
             'perms' => '\$user->rights->brevointegration->read',
@@ -94,7 +94,7 @@ class modBrevoIntegration extends DolibarrModules
             'leftmenu' => 'brevointegration_lists',
             'url' => '/brevointegration/brevointegration/lists.php',
             'langs' => 'brevointegration@brevointegration',
-            'picto' => 'icon-picto-brevo@brevointegration',
+            'picto' => 'icon-picto-brevo.svg@brevointegration',
             'position' => 101,
             'enabled' => '\$conf->brevointegration->enabled && \$user->rights->brevointegration->read',
             'perms' => '\$user->rights->brevointegration->read',
@@ -110,7 +110,7 @@ class modBrevoIntegration extends DolibarrModules
             'leftmenu' => 'brevointegration_logs',
             'url' => '/brevointegration/admin/logs.php',
             'langs' => 'brevointegration@brevointegration',
-            'picto' => 'icon-picto-brevo@brevointegration',
+            'picto' => 'icon-picto-brevo.svg@brevointegration',
             'position' => 102,
             'enabled' => '\$conf->brevointegration->enabled && \$user->admin',
             'perms' => '\$user->admin',

--- a/htdocs/custom/brevointegration/lists.php
+++ b/htdocs/custom/brevointegration/lists.php
@@ -87,7 +87,7 @@ if ($apiKey === '') {
 $title = $langs->trans('BrevoListsTitle');
 llxHeader('', $title);
 
-print load_fiche_titre($title, '', 'brevointegration@brevointegration');
+print load_fiche_titre($title, '', 'icon-picto-brevo.svg@brevointegration');
 
 if ($error !== '') {
     print '<div class="error">'.dol_escape_htmltag($error).'</div>';


### PR DESCRIPTION
## Summary
- reference the Brevo module SVG picto explicitly from the module descriptor and admin/list pages so Dolibarr can load it

## Testing
- php -l htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
- php -l htdocs/custom/brevointegration/admin/setup.php
- php -l htdocs/custom/brevointegration/admin/logs.php
- php -l htdocs/custom/brevointegration/lists.php

------
https://chatgpt.com/codex/tasks/task_e_68d7e2bac8688320b3462ff3fef34fe7