### PR TITLE
Add missing object icon for Brevo module

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Changed
 - Utilisation du picto Brevo dédié pour le module et ses menus Dolibarr.
 
+### Fixed
+- Ajout de l'icône `object_icon-picto-brevo.svg` pour l'affichage du module dans la liste Dolibarr.
+
 ## [1.2.1] - 2024-05-29
 ### Added
 - Stockage du libellé des listes Brevo synchronisées pour afficher un titre compréhensible dans les fiches contact et tiers.

--- a/htdocs/custom/brevointegration/img/object_icon-picto-brevo.svg
+++ b/htdocs/custom/brevointegration/img/object_icon-picto-brevo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="brevoGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1A73E8"></stop>
+      <stop offset="100%" stop-color="#00B0FF"></stop>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#brevoGradient)"></rect>
+  <path d="M12 20h40c2 0 3 1 3 3v18c0 2-1 3-3 3H12c-2 0-3-1-3-3V23c0-2 1-3 3-3z" fill="#fff"></path>
+  <path d="M12 20l20 16 20-16" fill="none" stroke="url(#brevoGradient)" stroke-width="4"></path>
+</svg>


### PR DESCRIPTION
## Summary
- add the object-prefixed Brevo icon used by the Dolibarr modules listing
- document the fix in the unreleased changelog section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e6807b888320ab8b4d0ed11b0af8