### PR TITLE
Fix Brevo logs admin link

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Ajout de l'icône `object_icon-picto-brevo.svg` pour l'affichage du module dans la liste Dolibarr.
+- Correction du lien de la roue dentée "Logs" pour les hébergements qui ne résolvaient pas le chemin `@brevointegration`.
 
 ## [1.2.1] - 2024-05-29
 ### Added

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -39,7 +39,10 @@ class modBrevoIntegration extends DolibarrModules
 
         $this->dirs = array();
 
-        $this->config_page_url = array('setup.php@brevointegration', 'logs.php@brevointegration');
+        $this->config_page_url = array(
+            'setup.php@brevointegration',
+            '../custom/brevointegration/admin/logs.php' // direct path so SaaS hosting resolves the custom admin page correctly
+        );
         $this->langfiles = array('brevointegration@brevointegration');
 
         $this->module_parts = array(


### PR DESCRIPTION
## Summary
- ensure the Brevo logs admin shortcut points to the custom module path even on SaaS hosts
- document the fix in the changelog

## Testing
- php -l htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php

------
https://chatgpt.com/codex/tasks/task_e_68d7e7b0a5208320bcbce2972a515877