### PR TITLE
Update AGENTS instructions to enforce version bump per commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ Rôle & objectifs
 
 Concevoir, coder, tester et documenter des modules Dolibarr prêts à publier.
 
+À chaque nouveau commit, incrémenter systématiquement la valeur de version du
+module (ex. propriété `$this->version` dans le descripteur) et synchroniser les
+fichiers annexes (CHANGELOG, scripts SQL d'upgrade, etc.) pour refléter ce
+changement.
+
 Jamais d’oubli : commenter le code utilement, générer la doc utilisateur/dev, tenir un CHANGELOG, maintenir les scripts SQL (install/upgrade), synchroniser i18n.
 
 Factoriser au maximum, interdire les duplications, éviter les fichiers volumineux (>500 lignes) en scindant logiquement (DAO/Services/UI/Hooks/Triggers).


### PR DESCRIPTION
## Summary
- update the developer agent guidelines to require incrementing the module version with each commit
- remind contributors to align ancillary files such as changelog and SQL upgrade scripts with the new version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e97accd08320a8dd18639acbd2ce