### PR TITLE
Ensure Brevo logs admin works when dol_include_once fails

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
 ## [Unreleased]
+
+## [1.2.2] - 2025-09-27
 ### Changed
 - Utilisation du picto Brevo dédié pour le module et ses menus Dolibarr.
 
 ### Fixed
 - Ajout de l'icône `object_icon-picto-brevo.svg` pour l'affichage du module dans la liste Dolibarr.
 - Correction du lien de la roue dentée "Logs" pour les hébergements qui ne résolvaient pas le chemin `@brevointegration`.
+- Ajout d'un repli d'inclusion pour charger les classes Brevo en environnement SaaS où `dol_include_once` ne résout pas le chemin personnalisé.
 
 ## [1.2.1] - 2024-05-29
 ### Added

--- a/htdocs/custom/brevointegration/admin/logs.php
+++ b/htdocs/custom/brevointegration/admin/logs.php
@@ -14,6 +14,9 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/list.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 dol_include_once('/brevointegration/class/services/brevologservice.class.php');
+if (!class_exists('BrevoLogService')) {
+    require_once __DIR__.'/../class/services/brevologservice.class.php';
+}
 
 global $langs, $user, $conf, $db;
 

--- a/htdocs/custom/brevointegration/class/services/brevologservice.class.php
+++ b/htdocs/custom/brevointegration/class/services/brevologservice.class.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
  */
 
 dol_include_once('/brevointegration/class/brevolog.class.php');
+if (!class_exists('BrevoLog')) {
+    require_once __DIR__.'/../brevolog.class.php';
+}
 
 /**
  * Class BrevoLogService

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -32,7 +32,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->editor_url = 'https://www.meditrust.fr';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.2.1';
+        $this->version = '1.2.2';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';


### PR DESCRIPTION
## Summary
- add a local fallback include in the Brevo logs admin page so the service class still loads when dol_include_once cannot resolve custom paths
- apply the same fallback in BrevoLogService for the DAO class to avoid class-not-found fatals on hosted environments
- bump the module version to 1.2.2 and document the fix in the changelog

## Testing
- php -l htdocs/custom/brevointegration/admin/logs.php
- php -l htdocs/custom/brevointegration/class/services/brevologservice.class.php

------
https://chatgpt.com/codex/tasks/task_e_68d7ea120e788320bc790e18467d0cf2