### PR TITLE
Fix Brevo logs date filter on PHP 7

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.2.3] - 2025-09-27
+### Fixed
+- Fallback vers `mktime` lorsque `dol_mktime` n'est pas disponible afin d'éviter l'erreur fatale sur la page des journaux.
+
 ## [1.2.2] - 2025-09-27
 ### Changed
 - Utilisation du picto Brevo dédié pour le module et ses menus Dolibarr.

--- a/htdocs/custom/brevointegration/admin/logs.php
+++ b/htdocs/custom/brevointegration/admin/logs.php
@@ -18,6 +18,33 @@ if (!class_exists('BrevoLogService')) {
     require_once __DIR__.'/../class/services/brevologservice.class.php';
 }
 
+/**
+ * Build a timestamp using Dolibarr helper when available, otherwise fallback to PHP's mktime.
+ *
+ * @param int|string $hour   Hour component
+ * @param int|string $minute Minute component
+ * @param int|string $second Second component
+ * @param int|string $month  Month component
+ * @param int|string $day    Day component
+ * @param int|string $year   Year component
+ * @return int
+ */
+function brevointegrationBuildTimestamp($hour, $minute, $second, $month, $day, $year)
+{
+    $hour = (int) $hour;
+    $minute = (int) $minute;
+    $second = (int) $second;
+    $month = (int) $month;
+    $day = (int) $day;
+    $year = (int) $year;
+
+    if (function_exists('dol_mktime')) {
+        return (int) dol_mktime($hour, $minute, $second, $month, $day, $year);
+    }
+
+    return (int) mktime($hour, $minute, $second, $month, $day, $year);
+}
+
 global $langs, $user, $conf, $db;
 
 if (!$user->admin) {
@@ -40,21 +67,21 @@ $startTimestamp = $defaultStart;
 $endTimestamp = $defaultEnd;
 
 if (!$resetFilter) {
-    $startTimestamp = dol_mktime(
+    $startTimestamp = brevointegrationBuildTimestamp(
         0,
         0,
         0,
-        (int) GETPOST('filter_startmonth', 'int'),
-        (int) GETPOST('filter_startday', 'int'),
-        (int) GETPOST('filter_startyear', 'int')
+        GETPOST('filter_startmonth', 'int'),
+        GETPOST('filter_startday', 'int'),
+        GETPOST('filter_startyear', 'int')
     );
-    $endTimestamp = dol_mktime(
+    $endTimestamp = brevointegrationBuildTimestamp(
         23,
         59,
         59,
-        (int) GETPOST('filter_endmonth', 'int'),
-        (int) GETPOST('filter_endday', 'int'),
-        (int) GETPOST('filter_endyear', 'int')
+        GETPOST('filter_endmonth', 'int'),
+        GETPOST('filter_endday', 'int'),
+        GETPOST('filter_endyear', 'int')
     );
 
     if ($startTimestamp <= 0) {

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -32,7 +32,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->editor_url = 'https://www.meditrust.fr';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.2.2';
+        $this->version = '1.2.3';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';


### PR DESCRIPTION
## Summary
- add a helper for building timestamps that falls back to PHP's `mktime` when `dol_mktime` is unavailable so the Brevo logs page works on PHP 7
- bump the module version to 1.2.3 and document the fix in the changelog

## Testing
- phpunit --configuration htdocs/custom/brevointegration/tests/phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d7ee7a39948320b2455361ed852ee5