### PR TITLE
Fix Brevo logs admin include handling and message access

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.2.4] - 2025-09-28
+### Fixed
+- Suppression du repli d'inclusion redondant sur la page des journaux pour éviter les erreurs fatales en environnement SaaS.
+- Protection de l'accès au message du journal lorsqu'il est absent afin d'éviter les notices en mode strict.
+
 ## [1.2.3] - 2025-09-27
 ### Fixed
 - Fallback vers `mktime` lorsque `dol_mktime` n'est pas disponible afin d'éviter l'erreur fatale sur la page des journaux.

--- a/htdocs/custom/brevointegration/admin/logs.php
+++ b/htdocs/custom/brevointegration/admin/logs.php
@@ -14,9 +14,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/list.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 dol_include_once('/brevointegration/class/services/brevologservice.class.php');
-if (!class_exists('BrevoLogService')) {
-    require_once __DIR__.'/../class/services/brevologservice.class.php';
-}
 
 /**
  * Build a timestamp using Dolibarr helper when available, otherwise fallback to PHP's mktime.
@@ -198,7 +195,7 @@ if (empty($logs)) {
         print '<td class="right">'.dol_escape_htmltag((string) $log['http_code']).'</td>';
         $durationLabel = sprintf($langs->trans('BrevoLogsDurationUnit'), (int) $log['duration_ms']);
         print '<td class="right">'.dol_escape_htmltag($durationLabel).'</td>';
-        $message = $log['message'] !== '' ? dol_escape_htmltag($log['message']) : '&nbsp;';
+        $message = !empty($log['message']) ? dol_escape_htmltag($log['message']) : '&nbsp;';
         print '<td>'.$message.'</td>';
         print '</tr>';
     }

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -32,7 +32,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->editor_url = 'https://www.meditrust.fr';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.2.3';
+        $this->version = '1.2.4';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';


### PR DESCRIPTION
## Summary
- remove the redundant fallback include in the Brevo logs admin page
- guard against missing log messages when rendering the list
- bump the module version to 1.2.4 and document the fixes in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f515921083208c05ad0deb8d035a