### PR TITLE
Fix Brevo logs admin loader for SaaS deployments

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.2.6] - 2025-09-30
+### Fixed
+- Renforcement du chargement de `main.inc.php` sur la page des journaux pour supporter les hébergements SaaS Dolibarr.
+
 ## [1.2.5] - 2025-09-29
 ### Added
 - Onglet de diagnostic sur la page de configuration affichant la version actuelle du module.

--- a/htdocs/custom/brevointegration/admin/logs.php
+++ b/htdocs/custom/brevointegration/admin/logs.php
@@ -8,7 +8,31 @@ declare(strict_types=1);
  * @brief     Administration page to inspect Brevo API logs.
  */
 
-require '../../../main.inc.php';
+// ---- Robust loader for main.inc.php (works with SaaS aliases) ----
+$res = 0;
+if (!$res && !empty($_SERVER['CONTEXT_DOCUMENT_ROOT'])) {
+    $res = @include $_SERVER['CONTEXT_DOCUMENT_ROOT'].'/main.inc.php';
+}
+if (!$res && !empty($_SERVER['DOCUMENT_ROOT'])) {
+    $res = @include $_SERVER['DOCUMENT_ROOT'].'/main.inc.php';
+}
+if (!$res && !empty($_SERVER['SCRIPT_FILENAME'])) {
+    $tmp = dirname($_SERVER['SCRIPT_FILENAME']);
+    for ($i = 0; $i < 10 && !$res; $i++) {
+        if (file_exists($tmp.'/main.inc.php')) {
+            $res = @include $tmp.'/main.inc.php';
+        }
+        $tmp = dirname($tmp);
+    }
+}
+if (!$res && file_exists(__DIR__.'/../../../main.inc.php')) {
+    $res = @include __DIR__.'/../../../main.inc.php';
+}
+if (!$res) {
+    http_response_code(500);
+    die('Failed to include Dolibarr main.inc.php');
+}
+// ------------------------------------------------------------------
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/list.lib.php';

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -32,7 +32,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->editor_url = 'https://www.meditrust.fr';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.2.5';
+        $this->version = '1.2.6';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';


### PR DESCRIPTION
## Summary
- add a robust fallback loader for `main.inc.php` on the Brevo logs admin page to support SaaS alias setups
- bump the module version to 1.2.6 and document the fix in the changelog

## Testing
- php -l htdocs/custom/brevointegration/admin/logs.php

------
https://chatgpt.com/codex/tasks/task_e_68d7f8bfe5408320bb811927a1ad65e4