### PR TITLE
Handle missing php-curl extension during Brevo API key validation

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.3.2] - 2025-10-03
+### Fixed
+- Empêche l'erreur fatale lors de la validation de la clé API lorsque l'extension PHP cURL est absente et affiche un message explicite.
+- Documente la dépendance à l'extension php-curl et localise le message d'erreur associé.
+
 ## [1.3.1] - 2025-10-02
 ### Fixed
 - Correction de l'URL de l'éditeur vers le domaine officiel `meditrust.io`.

--- a/htdocs/custom/brevointegration/README.md
+++ b/htdocs/custom/brevointegration/README.md
@@ -2,9 +2,10 @@
 
 ## Installation
 
-1. Copier le dossier `brevointegration` dans `htdocs/custom/` de votre instance Dolibarr 21.0.2.
-2. Connectez-vous en tant qu'administrateur et activez le module **Brevo Integration** depuis la page des modules.
-3. Exécutez le script SQL `sql/llx_brevo_contactsync.sql` via l'interface Dolibarr (ou import SQL) pour créer les tables de synchronisation et de journalisation (`llx_brevo_contactsync`, `llx_brevo_log`).
+1. Vérifiez que l'extension PHP **cURL** (`php-curl`) est installée et activée : le module l'utilise pour contacter l'API Brevo.
+2. Copier le dossier `brevointegration` dans `htdocs/custom/` de votre instance Dolibarr 21.0.2.
+3. Connectez-vous en tant qu'administrateur et activez le module **Brevo Integration** depuis la page des modules.
+4. Exécutez le script SQL `sql/llx_brevo_contactsync.sql` via l'interface Dolibarr (ou import SQL) pour créer les tables de synchronisation et de journalisation (`llx_brevo_contactsync`, `llx_brevo_log`).
 
 ### Déploiement via l'assistant Dolibarr
 

--- a/htdocs/custom/brevointegration/admin/setup.php
+++ b/htdocs/custom/brevointegration/admin/setup.php
@@ -134,7 +134,14 @@ if ($action === 'setapikey') {
             dolibarr_set_const($db, 'MAIN_BREVOINTEGRATION_APIKEY', $apiKey, 'chaine', 0, '', $conf->entity);
             setEventMessages($langs->trans('BrevoApiKeySaved'), null, 'mesgs');
         } else {
-            setEventMessages($response['error'], null, 'errors');
+            $errorMessage = isset($response['error']) ? (string) $response['error'] : '';
+            if ($errorMessage === 'Missing PHP cURL extension') {
+                $errorMessage = $langs->trans('BrevoMissingCurlExtension');
+            }
+            if ($errorMessage === '') {
+                $errorMessage = $langs->trans('Error');
+            }
+            setEventMessages($errorMessage, null, 'errors');
         }
     }
 } elseif ($action === 'savefieldmapping') {

--- a/htdocs/custom/brevointegration/class/brevoapi.class.php
+++ b/htdocs/custom/brevointegration/class/brevoapi.class.php
@@ -159,6 +159,12 @@ class BrevoApi
             return $this->formatError('Missing API key');
         }
 
+        if (!function_exists('curl_init')) {
+            $this->recordLog($method, $endpoint, 0, 0, false, 'Missing PHP cURL extension');
+
+            return $this->formatError('Missing PHP cURL extension');
+        }
+
         $startTime = microtime(true);
         $ch = curl_init($url);
         if ($ch === false) {

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -32,7 +32,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.1';
+        $this->version = '1.3.2';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';

--- a/htdocs/custom/brevointegration/langs/en_US/brevointegration.lang
+++ b/htdocs/custom/brevointegration/langs/en_US/brevointegration.lang
@@ -14,6 +14,7 @@ BrevoDiagnosticVersionLabel=Module version
 BrevoApiKeyLabel=Brevo API key
 BrevoApiKeySaved=API key validated and saved.
 BrevoApiKeyRemoved=API key removed.
+BrevoMissingCurlExtension=The PHP cURL extension is required to validate the API key. Enable php-curl on your server.
 BrevoMissingApiKey=Please provide a valid Brevo API key.
 BrevoMissingEmail=The contact has no email address.
 BrevoSelectList=Please choose a Brevo list.

--- a/htdocs/custom/brevointegration/langs/fr_FR/brevointegration.lang
+++ b/htdocs/custom/brevointegration/langs/fr_FR/brevointegration.lang
@@ -14,6 +14,7 @@ BrevoDiagnosticVersionLabel=Version du module
 BrevoApiKeyLabel=Clé API Brevo
 BrevoApiKeySaved=Clé API validée et enregistrée.
 BrevoApiKeyRemoved=Clé API supprimée.
+BrevoMissingCurlExtension=L'extension PHP cURL est requise pour valider la clé API. Activez le module php-curl sur votre serveur.
 BrevoMissingApiKey=Veuillez renseigner une clé API Brevo valide.
 BrevoMissingEmail=Le contact ne possède pas d'adresse e-mail.
 BrevoSelectList=Veuillez sélectionner une liste Brevo.


### PR DESCRIPTION
## Summary
- guard the Brevo API wrapper against missing php-curl to avoid fatal errors and return a translated admin notification
- document the php-curl requirement and add localized messaging for the new validation error
- bump module version to 1.3.2 and update the changelog accordingly

## Testing
- php -l htdocs/custom/brevointegration/class/brevoapi.class.php
- php -l htdocs/custom/brevointegration/admin/setup.php

------
https://chatgpt.com/codex/tasks/task_e_68d80351d41483209696e687661b3ec8