### PR TITLE
Handle unexpected errors when validating Brevo API key

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.3.5] - 2025-10-07
+### Fixed
+- Empêche les erreurs 500 lors de l'enregistrement de la clé API Brevo en encapsulant les appels HTTP dans une gestion d'exceptions robuste.
+- Ajout d'un test unitaire garantissant le retour d'un message d'erreur contrôlé quand la validation de clé déclenche une exception inattendue.
+
 ## [1.3.4] - 2025-10-06
 ### Added
 - Génération d'un patch SQL depuis l'onglet Diagnostic pour recréer la table `llx_brevo_log` ou ajouter les colonnes manquantes.

--- a/htdocs/custom/brevointegration/class/brevoapi.class.php
+++ b/htdocs/custom/brevointegration/class/brevoapi.class.php
@@ -67,7 +67,13 @@ class BrevoApi
     {
         $previous = $this->apiKey;
         $this->setApiKey($apiKey);
-        $response = $this->request('GET', '/account');
+
+        try {
+            $response = $this->request('GET', '/account');
+        } catch (Throwable $exception) {
+            $response = $this->formatError('Unexpected client error: '.$exception->getMessage());
+        }
+
         $this->setApiKey($previous);
 
         return $response;
@@ -165,63 +171,69 @@ class BrevoApi
             return $this->formatError('Missing PHP cURL extension');
         }
 
+        $method = strtoupper((string) $method);
         $startTime = microtime(true);
-        $ch = curl_init($url);
-        if ($ch === false) {
-            $this->recordLog($method, $endpoint, 0, 0, false, 'Unable to initialize curl');
 
-            return $this->formatError('Unable to initialize curl');
+        try {
+            $ch = curl_init($url);
+            if ($ch === false) {
+                throw new RuntimeException('Unable to initialize curl');
+            }
+
+            $payloadString = $payload ? json_encode($payload) : '';
+
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+            if ($method === 'POST' || $method === 'PUT' || $method === 'PATCH') {
+                curl_setopt($ch, CURLOPT_POSTFIELDS, $payloadString);
+            }
+
+            $response = curl_exec($ch);
+            $error = curl_error($ch);
+            $info = curl_getinfo($ch);
+            curl_close($ch);
+
+            $durationMs = (int) round((microtime(true) - $startTime) * 1000);
+
+            if ($response === false) {
+                $message = $error !== '' ? $error : 'Unknown curl error';
+                $this->recordLog($method, $endpoint, isset($info['http_code']) ? (int) $info['http_code'] : 0, $durationMs, false, $message);
+
+                return $this->formatError($message);
+            }
+
+            $decoded = json_decode($response, true);
+            if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+                $message = 'Invalid JSON response: '.json_last_error_msg();
+                $this->recordLog($method, $endpoint, isset($info['http_code']) ? (int) $info['http_code'] : 0, $durationMs, false, $message);
+
+                return $this->formatError($message);
+            }
+
+            $success = isset($info['http_code']) && $info['http_code'] >= 200 && $info['http_code'] < 300;
+            if (!$success) {
+                $message = isset($decoded['message']) ? $decoded['message'] : 'Unexpected HTTP status '.$info['http_code'];
+
+                $this->recordLog($method, $endpoint, isset($info['http_code']) ? (int) $info['http_code'] : 0, $durationMs, false, $message);
+
+                return $this->formatError($message, $info['http_code'], $decoded);
+            }
+
+            $this->recordLog($method, $endpoint, isset($info['http_code']) ? (int) $info['http_code'] : 200, $durationMs, true);
+
+            return array(
+                'success' => true,
+                'http_code' => isset($info['http_code']) ? (int) $info['http_code'] : 200,
+                'data' => $decoded,
+            );
+        } catch (Throwable $exception) {
+            $durationMs = (int) round((microtime(true) - $startTime) * 1000);
+            $this->recordLog($method, $endpoint, 0, $durationMs, false, $exception->getMessage());
+
+            return $this->formatError('Unexpected client error: '.$exception->getMessage());
         }
-
-        $method = strtoupper($method);
-        $payloadString = $payload ? json_encode($payload) : '';
-
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-        if ($method === 'POST' || $method === 'PUT' || $method === 'PATCH') {
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $payloadString);
-        }
-
-        $response = curl_exec($ch);
-        $error = curl_error($ch);
-        $info = curl_getinfo($ch);
-        curl_close($ch);
-
-        $durationMs = (int) round((microtime(true) - $startTime) * 1000);
-
-        if ($response === false) {
-            $message = $error !== '' ? $error : 'Unknown curl error';
-            $this->recordLog($method, $endpoint, isset($info['http_code']) ? (int) $info['http_code'] : 0, $durationMs, false, $message);
-
-            return $this->formatError($message);
-        }
-
-        $decoded = json_decode($response, true);
-        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
-            $message = 'Invalid JSON response: '.json_last_error_msg();
-            $this->recordLog($method, $endpoint, isset($info['http_code']) ? (int) $info['http_code'] : 0, $durationMs, false, $message);
-
-            return $this->formatError($message);
-        }
-
-        $success = isset($info['http_code']) && $info['http_code'] >= 200 && $info['http_code'] < 300;
-        if (!$success) {
-            $message = isset($decoded['message']) ? $decoded['message'] : 'Unexpected HTTP status '.$info['http_code'];
-
-            $this->recordLog($method, $endpoint, isset($info['http_code']) ? (int) $info['http_code'] : 0, $durationMs, false, $message);
-
-            return $this->formatError($message, $info['http_code'], $decoded);
-        }
-
-        $this->recordLog($method, $endpoint, isset($info['http_code']) ? (int) $info['http_code'] : 200, $durationMs, true);
-
-        return array(
-            'success' => true,
-            'http_code' => isset($info['http_code']) ? (int) $info['http_code'] : 200,
-            'data' => $decoded,
-        );
     }
 
     /**

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -32,7 +32,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.4';
+        $this->version = '1.3.5';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';

--- a/htdocs/custom/brevointegration/tests/unit/BrevoApiTest.php
+++ b/htdocs/custom/brevointegration/tests/unit/BrevoApiTest.php
@@ -74,4 +74,19 @@ class BrevoApiTest extends TestCase
 
         $this->assertSame('/contacts/lists/42', $api->lastEndpoint);
     }
+
+    public function testValidateApiKeyHandlesUnexpectedException(): void
+    {
+        $api = new class(new DoliDB(), new stdClass(), 'abc', new NullBrevoLogService()) extends BrevoApi {
+            protected function request($method, $endpoint, $payload = null)
+            {
+                throw new \RuntimeException('boom');
+            }
+        };
+
+        $response = $api->validateApiKey('abc');
+
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString('boom', $response['error']);
+    }
 }


### PR DESCRIPTION
## Summary
- guard the Brevo API client against unexpected exceptions so API key validation returns controlled errors instead of HTTP 500 responses
- bump the module version to 1.3.5 and document the fix in the changelog
- add a regression test ensuring validateApiKey surfaces handled error messages

## Testing
- php -l htdocs/custom/brevointegration/class/brevoapi.class.php
- php -l htdocs/custom/brevointegration/tests/unit/BrevoApiTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d80e8b85848320a3298f6580733cec