### PR TITLE
Handle missing PHP JSON extension during Brevo API validation

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.3.6] - 2025-10-08
+### Fixed
+- Empêche l'erreur fatale lors de la validation de la clé API lorsque l'extension PHP JSON est absente et affiche un message explicite.
+- Ajout d'un test unitaire garantissant le retour de l'erreur "Missing PHP JSON extension" et traduction associée.
+
 ## [1.3.5] - 2025-10-07
 ### Fixed
 - Empêche les erreurs 500 lors de l'enregistrement de la clé API Brevo en encapsulant les appels HTTP dans une gestion d'exceptions robuste.

--- a/htdocs/custom/brevointegration/README.md
+++ b/htdocs/custom/brevointegration/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-1. Vérifiez que l'extension PHP **cURL** (`php-curl`) est installée et activée : le module l'utilise pour contacter l'API Brevo.
+1. Vérifiez que les extensions PHP **cURL** (`php-curl`) et **JSON** (`php-json`) sont installées et activées : le module les utilise pour contacter l'API Brevo et décoder ses réponses.
 2. Copier le dossier `brevointegration` dans `htdocs/custom/` de votre instance Dolibarr 21.0.2.
 3. Connectez-vous en tant qu'administrateur et activez le module **Brevo Integration** depuis la page des modules.
 4. Exécutez le script SQL `sql/llx_brevo_contactsync.sql` via l'interface Dolibarr (ou import SQL) pour créer les tables de synchronisation et de journalisation (`llx_brevo_contactsync`, `llx_brevo_log`).

--- a/htdocs/custom/brevointegration/admin/setup.php
+++ b/htdocs/custom/brevointegration/admin/setup.php
@@ -219,6 +219,9 @@ if ($action === 'setapikey') {
             if ($errorMessage === 'Missing PHP cURL extension') {
                 $errorMessage = $langs->trans('BrevoMissingCurlExtension');
             }
+            if ($errorMessage === 'Missing PHP JSON extension') {
+                $errorMessage = $langs->trans('BrevoMissingJsonExtension');
+            }
             if ($errorMessage === '') {
                 $errorMessage = $langs->trans('Error');
             }

--- a/htdocs/custom/brevointegration/class/brevoapi.class.php
+++ b/htdocs/custom/brevointegration/class/brevoapi.class.php
@@ -171,6 +171,12 @@ class BrevoApi
             return $this->formatError('Missing PHP cURL extension');
         }
 
+        if (!$this->isJsonExtensionAvailable()) {
+            $this->recordLog($method, $endpoint, 0, 0, false, 'Missing PHP JSON extension');
+
+            return $this->formatError('Missing PHP JSON extension');
+        }
+
         $method = strtoupper((string) $method);
         $startTime = microtime(true);
 
@@ -234,6 +240,16 @@ class BrevoApi
 
             return $this->formatError('Unexpected client error: '.$exception->getMessage());
         }
+    }
+
+    /**
+     * Check whether the JSON extension is available.
+     *
+     * @return bool
+     */
+    protected function isJsonExtensionAvailable()
+    {
+        return function_exists('json_encode') && function_exists('json_decode');
     }
 
     /**

--- a/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevoIntegration.class.php
@@ -32,7 +32,7 @@ class modBrevoIntegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.5';
+        $this->version = '1.3.6';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';

--- a/htdocs/custom/brevointegration/langs/en_US/brevointegration.lang
+++ b/htdocs/custom/brevointegration/langs/en_US/brevointegration.lang
@@ -68,6 +68,7 @@ BrevoApiKeyLabel=Brevo API key
 BrevoApiKeySaved=API key validated and saved.
 BrevoApiKeyRemoved=API key removed.
 BrevoMissingCurlExtension=The PHP cURL extension is required to validate the API key. Enable php-curl on your server.
+BrevoMissingJsonExtension=The PHP JSON extension is required to validate the API key. Enable php-json on your server.
 BrevoMissingApiKey=Please provide a valid Brevo API key.
 BrevoMissingEmail=The contact has no email address.
 BrevoSelectList=Please choose a Brevo list.

--- a/htdocs/custom/brevointegration/langs/fr_FR/brevointegration.lang
+++ b/htdocs/custom/brevointegration/langs/fr_FR/brevointegration.lang
@@ -68,6 +68,7 @@ BrevoApiKeyLabel=Clé API Brevo
 BrevoApiKeySaved=Clé API validée et enregistrée.
 BrevoApiKeyRemoved=Clé API supprimée.
 BrevoMissingCurlExtension=L'extension PHP cURL est requise pour valider la clé API. Activez le module php-curl sur votre serveur.
+BrevoMissingJsonExtension=L'extension PHP JSON est requise pour valider la clé API. Activez le module php-json sur votre serveur.
 BrevoMissingApiKey=Veuillez renseigner une clé API Brevo valide.
 BrevoMissingEmail=Le contact ne possède pas d'adresse e-mail.
 BrevoSelectList=Veuillez sélectionner une liste Brevo.

--- a/htdocs/custom/brevointegration/tests/unit/BrevoApiTest.php
+++ b/htdocs/custom/brevointegration/tests/unit/BrevoApiTest.php
@@ -39,6 +39,23 @@ class BrevoApiTest extends TestCase
         $this->assertSame('Missing API key', $logService->records[0]['message']);
     }
 
+    public function testGetListsFailsWhenJsonExtensionMissing(): void
+    {
+        $logService = new NullBrevoLogService();
+        $api = new class(new DoliDB(), new stdClass(), 'abc', $logService) extends BrevoApi {
+            protected function isJsonExtensionAvailable()
+            {
+                return false;
+            }
+        };
+
+        $response = $api->getLists();
+
+        $this->assertFalse($response['success']);
+        $this->assertSame('Missing PHP JSON extension', $response['error']);
+        $this->assertSame('Missing PHP JSON extension', $logService->records[0]['message']);
+    }
+
     public function testUpsertContactCastsListIdsToIntegers(): void
     {
         $api = new class(new DoliDB(), new stdClass(), 'abc', new NullBrevoLogService()) extends BrevoApi {


### PR DESCRIPTION
## Summary
- guard Brevo API requests against missing PHP JSON support and surface a translated admin message
- document the JSON dependency and bump the module version to 1.3.6 with changelog updates
- cover the regression with a unit test that simulates the absence of json extension

## Testing
- phpunit -c tests/phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d813153e70832095dfec2dc85be61f