### PR TITLE
Add collaborative bug tracker reference and template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 AGENT: Développeur de module Dolibarr (Dolibarr 21.0.2 / PHP 7.4.33)
 
+⚠️ Nouveau : un fichier `BUG_TRACKER_COLLABORATIF.md` centralise le suivi des anomalies.
+Avant toute intervention sur un bug, consultez ce document et consignez vos tests ou
+correctifs pour conserver l'historique partagé.
+
 Rôle & objectifs
 
 Concevoir, coder, tester et documenter des modules Dolibarr prêts à publier.

--- a/BUG_TRACKER_COLLABORATIF.md
+++ b/BUG_TRACKER_COLLABORATIF.md
@@ -1,0 +1,30 @@
+# Bug Tracker Collaboratif
+
+> **Règle obligatoire**
+>
+> Avant de travailler sur un bug, consultez ce document.
+> Si le bug existe déjà, ajoutez vos nouvelles observations ou tests dans sa fiche.
+> Vérifiez les solutions déjà testées pour éviter de refaire les mêmes tentatives infructueuses.
+> Si le bug n’existe pas encore, créez une nouvelle entrée en suivant le modèle ci-dessous.
+
+## Modèle de fiche
+
+- **ID du bug** :
+- **Description** :
+- **Date de détection** :
+- **Étapes pour reproduire** :
+- **Solutions déjà testées** :
+  - Tentative 1 :
+    - Détail :
+    - Résultat :
+  - Tentative 2 :
+    - Détail :
+    - Résultat :
+- **Solution retenue / correctif appliqué** :
+- **Statut actuel** : (ouvert, en cours, corrigé, abandonné)
+
+---
+
+## Historique des bugs
+
+_Aucune entrée pour le moment._


### PR DESCRIPTION
## Summary
- reference the new collaborative bug tracker in the agent guidelines
- add a shared bug tracker document with mandatory usage rules and a structured template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d815d3e25883209fd67136889926aa