### PR TITLE
Fix checkToken fatal error on Brevo setup page

### DIFF
--- a/BUG_TRACKER_COLLABORATIF.md
+++ b/BUG_TRACKER_COLLABORATIF.md
@@ -60,3 +60,17 @@
     - Résultat : SQL pouvant échouer selon la configuration → 500.
 - **Solution retenue / correctif appliqué** : Introduction d'un client `BrevoClient` tolérant aux erreurs, séparation des actions « Enregistrer » / « Tester » avec vérification CSRF, requêtes SQL paginées sécurisées et messages utilisateur via `setEventMessages()`.
 - **Statut actuel** : corrigé
+
+### BUG-2025-10-12-SETUP-CHECKTOKEN
+- **ID du bug** : BUG-2025-10-12-SETUP-CHECKTOKEN
+- **Description** : Erreur fatale « Call to undefined function checkToken() » lors de l'enregistrement ou des actions POST sur `custom/brevointegration/admin/setup.php`.
+- **Date de détection** : 2025-10-12
+- **Étapes pour reproduire** :
+  1. Ouvrir `custom/brevointegration/admin/setup.php`.
+  2. Soumettre le formulaire (enregistrement de clé, test de connexion, mappings…).
+  3. Constater l'erreur 500 avec le message « Call to undefined function checkToken() » dans les logs.
+- **Solutions déjà testées** :
+  - Tentative 1 : Conserver les inclusions actuelles (`admin.lib.php` uniquement).
+    - Résultat : fonction `checkToken()` absente → erreur fatale.
+- **Solution retenue / correctif appliqué** : Charger explicitement `core/lib/security.lib.php` dans la page de configuration et les hooks pour garantir la disponibilité de `checkToken()`.
+- **Statut actuel** : corrigé

--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.3.10] - 2025-10-12
+### Fixed
+- Ajout explicite du chargement de `security.lib.php` pour rétablir la fonction `checkToken()` sur la page de configuration Brevo et dans les hooks.
+
 ## [1.3.9] - 2025-10-11
 ### Added
 - Diagnostic write test covering INSERT/UPDATE/DELETE on `llx_brevo_log` to detect permission issues proactively.

--- a/htdocs/custom/brevointegration/admin/setup.php
+++ b/htdocs/custom/brevointegration/admin/setup.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 require __DIR__.'/../../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 dol_include_once('/brevointegration/class/BrevoClient.class.php');
 dol_include_once('/brevointegration/class/services/brevofieldmappingservice.class.php');
 dol_include_once('/brevointegration/class/services/brevocategorymappingservice.class.php');

--- a/htdocs/custom/brevointegration/class/actions_brevointegration.class.php
+++ b/htdocs/custom/brevointegration/class/actions_brevointegration.class.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  */
 
 require_once DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
 require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';

--- a/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
@@ -32,7 +32,7 @@ class modBrevointegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.9';
+        $this->version = '1.3.10';
         $this->const_name = 'BREVO_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';


### PR DESCRIPTION
## Summary
- load Dolibarr security helpers on the Brevo setup page and hooks to make checkToken() available
- bump the module version to 1.3.10 and document the fix in the changelog and bug tracker

## Testing
- php -l htdocs/custom/brevointegration/admin/setup.php
- php -l htdocs/custom/brevointegration/class/actions_brevointegration.class.php
- php -l htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php

------
https://chatgpt.com/codex/tasks/task_e_68d81f54cf7c8320b287251554743267