### PR TITLE
Fix Brevo logs admin crash when missing column metadata is invalid

### DIFF
--- a/BUG_TRACKER_COLLABORATIF.md
+++ b/BUG_TRACKER_COLLABORATIF.md
@@ -74,3 +74,17 @@
     - Résultat : fonction `checkToken()` absente → erreur fatale.
 - **Solution retenue / correctif appliqué** : Charger explicitement `core/lib/security.lib.php` dans la page de configuration et les hooks pour garantir la disponibilité de `checkToken()`.
 - **Statut actuel** : corrigé
+
+### BUG-2025-10-13-LOGS-MISSINGCOLS
+- **ID du bug** : BUG-2025-10-13-LOGS-MISSINGCOLS
+- **Description** : Erreur 500 sur `custom/brevointegration/admin/logs.php` lorsque `BrevoDatabaseMaintenanceService` retourne une liste de colonnes manquantes `null`, provoquant un `TypeError` sans trace dans `dolibarr.log`.
+- **Date de détection** : 2025-10-13
+- **Étapes pour reproduire** :
+  1. Forcer un retour incohérent de `getLogTableStatus()` (ex. hook tiers ou ancien cache retournant `missing_columns = null`).
+  2. Ouvrir `custom/brevointegration/admin/logs.php`.
+  3. Constater l'erreur 500 et l'absence de journalisation.
+- **Solutions déjà testées** :
+  - Tentative 1 : Aucun traitement spécifique, laisser PHP remonter l'exception `TypeError`.
+    - Résultat : Erreur 500 persistante sans trace exploitable.
+- **Solution retenue / correctif appliqué** : Normalisation défensive des métadonnées de schéma dans `BrevoLogService`, conversion des colonnes en tableau typé et ajout d'une journalisation explicite côté interface admin.
+- **Statut actuel** : corrigé

--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.3.11] - 2025-10-13
+### Fixed
+- Normalisation défensive du statut de la table `llx_brevo_log` pour éviter l'erreur 500 lorsque la liste des colonnes manquantes est invalide.
+- Journalisation explicite des anomalies de schéma sur la page des journaux afin de laisser des traces exploitables dans `dolibarr.log`.
+
 ## [1.3.10] - 2025-10-12
 ### Fixed
 - Ajout explicite du chargement de `security.lib.php` pour rétablir la fonction `checkToken()` sur la page de configuration Brevo et dans les hooks.

--- a/htdocs/custom/brevointegration/admin/logs.php
+++ b/htdocs/custom/brevointegration/admin/logs.php
@@ -139,8 +139,16 @@ if ($limit) {
 if (!$storageStatus['exists']) {
     setEventMessages($langs->trans('BrevoLogsStorageMissingTable', dol_escape_htmltag($storageStatus['table_name'])), null, 'warnings');
 } elseif (!$storageStatus['ready']) {
-    $missingColumns = array_map('dol_escape_htmltag', $storageStatus['missing_columns']);
-    $missingList = implode(', ', $missingColumns);
+    $missingColumns = array();
+    if (!empty($storageStatus['missing_columns'])) {
+        if (is_array($storageStatus['missing_columns'])) {
+            $missingColumns = array_map('dol_escape_htmltag', $storageStatus['missing_columns']);
+        } else {
+            dol_syslog(__FILE__.' unexpected missing_columns payload type: '.gettype($storageStatus['missing_columns']), LOG_ERR);
+            $missingColumns = array(dol_escape_htmltag((string) $storageStatus['missing_columns']));
+        }
+    }
+    $missingList = !empty($missingColumns) ? implode(', ', $missingColumns) : dol_escape_htmltag($langs->trans('Unknown'));
     setEventMessages($langs->trans('BrevoLogsStorageMissingColumns', $missingList), null, 'warnings');
 } else {
     $conditions = array('entity = '.((int) $conf->entity));

--- a/htdocs/custom/brevointegration/class/services/brevologservice.class.php
+++ b/htdocs/custom/brevointegration/class/services/brevologservice.class.php
@@ -245,11 +245,70 @@ class BrevoLogService
      */
     public function getLogStorageStatus()
     {
-        $status = $this->maintenanceService->getLogTableStatus();
+        $defaultStatus = array(
+            'table_name' => $this->maintenanceService->getLogTableName(),
+            'exists' => false,
+            'ready' => false,
+            'missing_columns' => array(),
+            'available_columns' => array()
+        );
+
+        try {
+            $status = $this->maintenanceService->getLogTableStatus();
+        } catch (Throwable $exception) {
+            dol_syslog(__METHOD__.' unexpected exception: '.$exception->getMessage(), LOG_ERR);
+            $status = $defaultStatus;
+        }
+
+        if (!is_array($status)) {
+            dol_syslog(__METHOD__.' invalid status payload type: '.gettype($status), LOG_ERR);
+            $status = $defaultStatus;
+        } else {
+            $status = array_merge($defaultStatus, $status);
+        }
+
+        $status['exists'] = !empty($status['exists']);
+        $status['missing_columns'] = $this->sanitizeColumnList($status['missing_columns'], 'missing_columns');
+        $status['available_columns'] = $this->sanitizeColumnList($status['available_columns'], 'available_columns');
+        $status['ready'] = $status['exists'] && empty($status['missing_columns']);
+
         $fields = !empty($status['available_columns']) ? $this->normalizeFieldMap($status['available_columns']) : array();
         $this->logTableSchema = array('exists' => $status['exists'], 'fields' => $fields);
 
         return $status;
+    }
+
+    /**
+     * Normalise arbitrary payloads into a list of column names.
+     *
+     * @param mixed  $value   Raw payload
+     * @param string $context Context identifier for logging
+     * @return array<int,string>
+     */
+    private function sanitizeColumnList($value, $context)
+    {
+        if (is_array($value)) {
+            $columns = array();
+            foreach ($value as $column) {
+                if ($column === null || $column === '') {
+                    continue;
+                }
+
+                $columns[] = (string) $column;
+            }
+
+            return $columns;
+        }
+
+        if ($value === null || $value === '') {
+            dol_syslog(__METHOD__.' unexpected empty '.$context.' payload', LOG_WARNING);
+
+            return array();
+        }
+
+        dol_syslog(__METHOD__.' unexpected '.$context.' payload type: '.gettype($value), LOG_WARNING);
+
+        return array((string) $value);
     }
 
     /**

--- a/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
@@ -32,7 +32,7 @@ class modBrevointegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.10';
+        $this->version = '1.3.11';
         $this->const_name = 'BREVO_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';

--- a/htdocs/custom/brevointegration/tests/unit/BrevoLogServiceTest.php
+++ b/htdocs/custom/brevointegration/tests/unit/BrevoLogServiceTest.php
@@ -373,4 +373,60 @@ class BrevoLogServiceTest extends TestCase
 
         $this->assertCount(0, $db->data);
     }
+
+    public function testGetLogStorageStatusNormalizesMissingColumns(): void
+    {
+        $db = new FakeBrevoLogDB();
+        $conf = new stdClass();
+        $conf->entity = 1;
+
+        $service = new BrevoLogService($db, $conf);
+
+        $reflection = new ReflectionClass($service);
+        $property = $reflection->getProperty('maintenanceService');
+        $property->setAccessible(true);
+        $property->setValue($service, new class($db) {
+            /** @var FakeBrevoLogDB */
+            private $db;
+
+            public function __construct($db)
+            {
+                $this->db = $db;
+            }
+
+            public function getLogTableStatus()
+            {
+                return array(
+                    'table_name' => 'llx_brevo_log',
+                    'exists' => true,
+                    'ready' => true,
+                    'missing_columns' => null,
+                    'available_columns' => 'rowid'
+                );
+            }
+
+            public function getLogTableName()
+            {
+                return 'llx_brevo_log';
+            }
+
+            public function getLogTableSchema()
+            {
+                return array('exists' => true, 'fields' => array('rowid' => 'rowid'));
+            }
+        });
+
+        $status = $service->getLogStorageStatus();
+
+        $this->assertTrue($status['exists']);
+        $this->assertTrue($status['ready']);
+        $this->assertSame(array(), $status['missing_columns']);
+        $this->assertSame(array('rowid'), $status['available_columns']);
+
+        $schemaProperty = $reflection->getProperty('logTableSchema');
+        $schemaProperty->setAccessible(true);
+        $schema = $schemaProperty->getValue($service);
+
+        $this->assertSame(array('exists' => true, 'fields' => array('rowid' => 'rowid')), $schema);
+    }
 }


### PR DESCRIPTION
## Summary
- normalize the Brevo log storage status payload to tolerate null/invalid column lists and emit diagnostic logs
- harden the admin logs page so missing column warnings render without fatal errors and leave traces in dolibarr.log
- add a regression test, bump the module version to 1.3.11, and document the fix in the changelog and bug tracker

## Testing
- phpunit --configuration htdocs/custom/brevointegration/tests/phpunit.xml.dist

------
https://chatgpt.com/codex/tasks/task_e_68d8201b4bec8320b8027332a3d81025