### PR TITLE
Fix SQL datetime quoting in Brevo module

### DIFF
--- a/BUG_TRACKER_COLLABORATIF.md
+++ b/BUG_TRACKER_COLLABORATIF.md
@@ -88,3 +88,17 @@
     - Résultat : Erreur 500 persistante sans trace exploitable.
 - **Solution retenue / correctif appliqué** : Normalisation défensive des métadonnées de schéma dans `BrevoLogService`, conversion des colonnes en tableau typé et ajout d'une journalisation explicite côté interface admin.
 - **Statut actuel** : corrigé
+
+### BUG-2025-10-14-LOGS-IDATE-QUOTE
+- **ID du bug** : BUG-2025-10-14-LOGS-IDATE-QUOTE
+- **Description** : Les insertions dans `llx_brevo_log` échouent sur MariaDB/MySQL avec `DB_ERROR_SYNTAX` car `DoliDB::idate()` renvoie une date non quotée dans les requêtes construites dynamiquement.
+- **Date de détection** : 2025-10-14
+- **Étapes pour reproduire** :
+  1. Activer le module et lancer le test Diagnostic (`/brevointegration/diagnostic`).
+  2. Observer la requête `INSERT` générée sans quotes autour de `date_event`.
+  3. Constater l'erreur SQL dans `dolibarr.log`.
+- **Solutions déjà testées** :
+  - Tentative 1 : Encapsuler uniquement le fallback `date('Y-m-d H:i:s')` dans des quotes.
+    - Résultat : Marche seulement lorsque `idate()` n'est pas disponible.
+- **Solution retenue / correctif appliqué** : Ajout du helper `brevointegration_format_sql_datetime()` forçant les quotes si nécessaire et utilisation systématique dans `BrevoLogService`, `BrevoLog`, `BrevoSync` et `admin/logs.php`.
+- **Statut actuel** : corrigé

--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.3.12] - 2025-10-14
+### Fixed
+- Encadrement systématique des dates SQL via un helper dédié pour éviter les erreurs de syntaxe lorsque `DoliDB::idate()` ne renvoie pas de quotes (MySQL/MariaDB).
+- Sécurisation des enregistrements `BrevoSync` et `BrevoLog` avec le même helper afin de garantir la compatibilité multi-SGBD.
+
 ## [1.3.11] - 2025-10-13
 ### Fixed
 - Normalisation défensive du statut de la table `llx_brevo_log` pour éviter l'erreur 500 lorsque la liste des colonnes manquantes est invalide.

--- a/htdocs/custom/brevointegration/admin/logs.php
+++ b/htdocs/custom/brevointegration/admin/logs.php
@@ -15,6 +15,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/list.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 dol_include_once('/brevointegration/class/services/brevologservice.class.php');
+dol_include_once('/brevointegration/lib/brevointegration_date.lib.php');
 
 /**
  * Build a timestamp using Dolibarr helper when available, otherwise fallback to PHP's mktime.
@@ -154,10 +155,16 @@ if (!$storageStatus['exists']) {
     $conditions = array('entity = '.((int) $conf->entity));
 
     if ($startTimestamp > 0) {
-        $conditions[] = 'date_event >= '.(method_exists($db, 'idate') ? $db->idate($startTimestamp) : "'".date('Y-m-d H:i:s', (int) $startTimestamp)."'");
+        $startSql = brevointegration_format_sql_datetime($db, $startTimestamp);
+        if ($startSql !== null) {
+            $conditions[] = 'date_event >= '.$startSql;
+        }
     }
     if ($endTimestamp > 0) {
-        $conditions[] = 'date_event <= '.(method_exists($db, 'idate') ? $db->idate($endTimestamp) : "'".date('Y-m-d H:i:s', (int) $endTimestamp)."'");
+        $endSql = brevointegration_format_sql_datetime($db, $endTimestamp);
+        if ($endSql !== null) {
+            $conditions[] = 'date_event <= '.$endSql;
+        }
     }
 
     $whereClause = implode(' AND ', $conditions);

--- a/htdocs/custom/brevointegration/class/brevolog.class.php
+++ b/htdocs/custom/brevointegration/class/brevolog.class.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  */
 
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
+dol_include_once('/brevointegration/lib/brevointegration_date.lib.php');
 
 /**
  * Class BrevoLog
@@ -73,11 +74,11 @@ class BrevoLog extends CommonObject
         $sql .= 'entity, date_event, method, endpoint, http_code, duration_ms, success, message';
         $sql .= ') VALUES (';
         $sql .= (int) $this->entity.',';
-        if (method_exists($this->db, 'idate')) {
-            $sql .= $this->db->idate($now).',';
-        } else {
-            $sql .= "'".date('Y-m-d H:i:s', (int) $now)."',";
+        $dateSql = brevointegration_format_sql_datetime($this->db, $now);
+        if ($dateSql === null) {
+            $dateSql = "'".date('Y-m-d H:i:s', (int) $now)."'";
         }
+        $sql .= $dateSql.',';
         $sql .= "'".$this->db->escape($this->method)."',";
         $sql .= "'".$this->db->escape($this->endpoint)."',";
         $sql .= (int) $this->http_code.',';

--- a/htdocs/custom/brevointegration/class/brevosync.class.php
+++ b/htdocs/custom/brevointegration/class/brevosync.class.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
+dol_include_once('/brevointegration/lib/brevointegration_date.lib.php');
 
 /**
  * Class BrevoSync
@@ -96,7 +97,8 @@ class BrevoSync extends CommonObject
             if ($this->brevo_list_label !== '') {
                 $update .= ", brevo_list_label='".$this->db->escape($this->brevo_list_label)."'";
             }
-            $update .= ', date_sync='.$this->db->idate($now);
+            $dateSql = brevointegration_format_sql_datetime($this->db, $now);
+            $update .= ', date_sync='.($dateSql !== null ? $dateSql : 'NULL');
             $update .= ' WHERE rowid='.(int) $obj->rowid;
 
             $res = $this->db->query($update);
@@ -115,7 +117,8 @@ class BrevoSync extends CommonObject
             $sql .= (int) $this->brevo_list_id.',';
             $sql .= "'".$this->db->escape($this->brevo_list_label)."',";
             $sql .= "'".$this->db->escape($this->brevo_contact_id)."',";
-            $sql .= $this->db->idate($now).',';
+            $dateSql = brevointegration_format_sql_datetime($this->db, $now);
+            $sql .= ($dateSql !== null ? $dateSql : 'NULL').',';
             $sql .= "'".$this->db->escape($this->status)."')";
 
             $res = $this->db->query($sql);
@@ -145,7 +148,8 @@ class BrevoSync extends CommonObject
     {
         $sql = 'UPDATE '.MAIN_DB_PREFIX.$this->table_element;
         $sql .= " SET status='removed'";
-        $sql .= ', date_sync='.$this->db->idate(dol_now());
+        $dateSql = brevointegration_format_sql_datetime($this->db, dol_now());
+        $sql .= ', date_sync='.($dateSql !== null ? $dateSql : 'NULL');
         global $conf;
         $entity = isset($conf->entity) ? (int) $conf->entity : 1;
 

--- a/htdocs/custom/brevointegration/class/services/brevologservice.class.php
+++ b/htdocs/custom/brevointegration/class/services/brevologservice.class.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  */
 
 dol_include_once('/brevointegration/class/services/brevodatabasemaintenanceservice.class.php');
+dol_include_once('/brevointegration/lib/brevointegration_date.lib.php');
 
 /**
  * Class BrevoLogService
@@ -65,7 +66,10 @@ class BrevoLogService
         }
 
         $now = dol_now();
-        $dateSql = method_exists($this->db, 'idate') ? $this->db->idate($now) : "'".date('Y-m-d H:i:s', (int) $now)."'";
+        $dateSql = brevointegration_format_sql_datetime($this->db, $now);
+        if ($dateSql === null) {
+            $dateSql = "'".date('Y-m-d H:i:s', (int) $now)."'";
+        }
 
         $sql = "INSERT INTO ".MAIN_DB_PREFIX."brevo_log (entity, date_event, method, endpoint, http_code, duration_ms, success, message) VALUES (";
         $sql .= (int) $this->getEntity().',';
@@ -631,11 +635,12 @@ class BrevoLogService
             return null;
         }
 
-        if (method_exists($this->db, 'idate')) {
-            return $this->db->idate($timestamp);
+        $formatted = brevointegration_format_sql_datetime($this->db, $timestamp);
+        if ($formatted === null) {
+            $formatted = "'".date('Y-m-d H:i:s', $timestamp)."'";
         }
 
-        return "'".date('Y-m-d H:i:s', $timestamp)."'";
+        return $formatted;
     }
 
     /**

--- a/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
@@ -32,7 +32,7 @@ class modBrevointegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.11';
+        $this->version = '1.3.12';
         $this->const_name = 'BREVO_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';

--- a/htdocs/custom/brevointegration/lib/brevointegration_date.lib.php
+++ b/htdocs/custom/brevointegration/lib/brevointegration_date.lib.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package   brevointegration
+ * @author    Meditrust
+ * @license   GPL-3.0-or-later
+ * @brief     Helper functions to normalise SQL datetime literals for Brevo module.
+ */
+
+if (!function_exists('brevointegration_format_sql_datetime')) {
+    /**
+     * Format a timestamp into a SQL literal or expression compatible with the current database handler.
+     * Ensures the resulting value is quoted when the connector returns raw date strings (MySQL/MariaDB).
+     *
+     * @param DoliDB|mixed $db        Database handler
+     * @param int          $timestamp Unix timestamp
+     * @return string|null            SQL-ready datetime literal/expression or null on failure
+     */
+    function brevointegration_format_sql_datetime($db, $timestamp)
+    {
+        $timestamp = (int) $timestamp;
+        if ($timestamp <= 0 || !is_object($db)) {
+            return null;
+        }
+
+        $value = null;
+        if (method_exists($db, 'idate')) {
+            $value = $db->idate($timestamp);
+            if (!is_string($value)) {
+                $value = (string) $value;
+            }
+            $value = trim($value);
+            if ($value === '') {
+                $value = null;
+            }
+        }
+
+        if ($value === null) {
+            $value = date('Y-m-d H:i:s', $timestamp);
+        }
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $firstChar = $value[0];
+        $lastChar = substr($value, -1);
+        if ($firstChar === "'" && $lastChar === "'") {
+            return $value;
+        }
+
+        $upper = strtoupper($value);
+        if (strpos($value, '(') !== false || strpos($value, ')') !== false || strpos($upper, 'DATE') !== false || strpos($upper, 'TIME') !== false) {
+            return $value;
+        }
+
+        return "'".$value."'";
+    }
+}

--- a/htdocs/custom/brevointegration/tests/unit/BrevoLogServiceTest.php
+++ b/htdocs/custom/brevointegration/tests/unit/BrevoLogServiceTest.php
@@ -37,6 +37,15 @@ class FakeBrevoLogDB extends DoliDB
     /** @var array<int,string> */
     public $schemaColumns = array('rowid', 'entity', 'date_event', 'method', 'endpoint', 'http_code', 'duration_ms', 'success', 'message');
 
+    /** @var bool */
+    public $idateRawMode = false;
+
+    /** @var string */
+    public $lastInsertSql = '';
+
+    /** @var string */
+    public $lastDateLiteral = '';
+
     public function escape($value)
     {
         return addslashes((string) $value);
@@ -44,7 +53,12 @@ class FakeBrevoLogDB extends DoliDB
 
     public function idate($timestamp)
     {
-        return "'".date('Y-m-d H:i:s', (int) $timestamp)."'";
+        $formatted = date('Y-m-d H:i:s', (int) $timestamp);
+        if ($this->idateRawMode) {
+            return $formatted;
+        }
+
+        return "'".$formatted."'";
     }
 
     public function jdate($dateValue)
@@ -128,6 +142,7 @@ class FakeBrevoLogDB extends DoliDB
 
     private function handleInsert($sql)
     {
+        $this->lastInsertSql = $sql;
         if (!preg_match('/VALUES \((.+)\)$/i', trim($sql), $matches)) {
             $this->lasterror = 'Malformed INSERT';
 
@@ -135,6 +150,7 @@ class FakeBrevoLogDB extends DoliDB
         }
 
         $values = $this->splitValues($matches[1]);
+        $this->lastDateLiteral = $values[1];
 
         $this->data[] = array(
             'rowid' => count($this->data) + 1,
@@ -359,6 +375,24 @@ class BrevoLogServiceTest extends TestCase
 
         $this->assertSame(0, $result['total']);
         $this->assertCount(0, $result['logs']);
+    }
+
+    public function testRecordQuotesDateWhenConnectorReturnsRawValue(): void
+    {
+        $db = new FakeBrevoLogDB();
+        $db->idateRawMode = true;
+        $conf = new stdClass();
+        $conf->entity = 2;
+
+        $service = new BrevoLogService($db, $conf);
+        $service->record('GET', '/ping', 200, 10, true, '');
+
+        $this->assertNotSame('', $db->lastInsertSql);
+        $this->assertNotSame('', $db->lastDateLiteral);
+        $literal = trim($db->lastDateLiteral);
+        $this->assertSame("'", $literal[0], 'Date literal must start with a quote');
+        $this->assertSame("'", substr($literal, -1), 'Date literal must end with a quote');
+        $this->assertCount(1, $db->data);
     }
 
     public function testLogRequestSkippedWhenSchemaIncomplete(): void


### PR DESCRIPTION
## Summary
- add a shared helper to normalise SQL datetime literals and load it where needed
- update Brevo log/service/DAO code and admin logs page to use the helper and cover the regression with a unit test
- bump the module to 1.3.12 and document the fix in the changelog and bug tracker

## Testing
- php -l htdocs/custom/brevointegration/class/services/brevologservice.class.php htdocs/custom/brevointegration/admin/logs.php htdocs/custom/brevointegration/class/brevosync.class.php htdocs/custom/brevointegration/class/brevolog.class.php htdocs/custom/brevointegration/tests/unit/BrevoLogServiceTest.php htdocs/custom/brevointegration/lib/brevointegration_date.lib.php
- phpunit -c htdocs/custom/brevointegration/tests/phpunit.xml.dist --filter BrevoLogServiceTest

------
https://chatgpt.com/codex/tasks/task_e_68d82424991c8320b04fe6a1e9da2d3f