### PR TITLE
Add CSRF fallback helper for Brevo admin flows

### DIFF
--- a/BUG_TRACKER_COLLABORATIF.md
+++ b/BUG_TRACKER_COLLABORATIF.md
@@ -102,3 +102,17 @@
     - Résultat : Marche seulement lorsque `idate()` n'est pas disponible.
 - **Solution retenue / correctif appliqué** : Ajout du helper `brevointegration_format_sql_datetime()` forçant les quotes si nécessaire et utilisation systématique dans `BrevoLogService`, `BrevoLog`, `BrevoSync` et `admin/logs.php`.
 - **Statut actuel** : corrigé
+
+### BUG-2025-10-15-CSRF-FALLBACK
+- **ID du bug** : BUG-2025-10-15-CSRF-FALLBACK
+- **Description** : Environnements mutualisés ne chargeant pas `functions.lib.php` / `security.lib.php` provoquant toujours l'erreur fatale « Call to undefined function checkToken() » sur `admin/setup.php` et les hooks Brevo, empêchant la sauvegarde de la clé API et la désactivation du module.
+- **Date de détection** : 2025-10-15
+- **Étapes pour reproduire** :
+  1. Déployer Dolibarr avec un loader restreint ne fournissant pas `checkToken()` / `newToken()` au module.
+  2. Ouvrir `custom/brevointegration/admin/setup.php` et soumettre un formulaire ou utiliser les boutons Brevo sur une fiche contact.
+  3. Constater l'erreur HTTP 500 et la trace « Call to undefined function checkToken() » dans `dolibarr.log`.
+- **Solutions déjà testées** :
+  - Tentative 1 : Charger directement `security.lib.php` depuis la page d'administration.
+    - Résultat : Toujours en échec lorsque l'hébergeur bloque l'inclusion (fichier absent ou chemin filtré).
+- **Solution retenue / correctif appliqué** : Création d'un helper `brevointegration_security.lib.php` qui tente de charger les bibliothèques natives et fournit un repli CSRF contrôlé (journalisation + génération/validation locale) pour éviter l'erreur 500.
+- **Statut actuel** : corrigé

--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.3.13] - 2025-10-15
+### Fixed
+- Ajout d'un helper de sécurité dédié pour charger automatiquement les bibliothèques Dolibarr et fournir un repli CSRF afin d'éviter l'erreur fatale « Call to undefined function checkToken() ».
+- Sécurisation des formulaires d'administration et des hooks Brevo en utilisant le nouveau helper `brevointegration_check_token()` et des jetons générés de manière résiliente.
+- Prévention d'un blocage de l'interface Dolibarr (désactivation du module, sauvegarde de clé ou consultation des journaux) lorsque les fonctions de jeton natives sont indisponibles.
+
 ## [1.3.12] - 2025-10-14
 ### Fixed
 - Encadrement systématique des dates SQL via un helper dédié pour éviter les erreurs de syntaxe lorsque `DoliDB::idate()` ne renvoie pas de quotes (MySQL/MariaDB).

--- a/htdocs/custom/brevointegration/admin/setup.php
+++ b/htdocs/custom/brevointegration/admin/setup.php
@@ -16,6 +16,9 @@ dol_include_once('/brevointegration/class/services/brevofieldmappingservice.clas
 dol_include_once('/brevointegration/class/services/brevocategorymappingservice.class.php');
 dol_include_once('/brevointegration/class/services/brevologservice.class.php');
 dol_include_once('/brevointegration/class/services/brevodatabasemaintenanceservice.class.php');
+dol_include_once('/brevointegration/lib/brevointegration_security.lib.php');
+
+brevointegration_require_security_libs();
 
 global $langs, $user, $conf, $db;
 
@@ -201,7 +204,7 @@ if (!in_array($selectedTab, $availableTabs, true)) {
 
 try {
     if ($action === 'saveapikey') {
-        if (!checkToken()) {
+        if (!brevointegration_check_token()) {
             accessforbidden();
         }
 
@@ -218,7 +221,7 @@ try {
 
         $action = '';
     } elseif ($action === 'testapikey') {
-        if (!checkToken()) {
+        if (!brevointegration_check_token()) {
             accessforbidden();
         }
 
@@ -254,7 +257,7 @@ try {
 }
 
 if ($action === 'savefieldmapping') {
-    if (!checkToken()) {
+    if (!brevointegration_check_token()) {
         accessforbidden();
     }
 
@@ -269,7 +272,7 @@ if ($action === 'savefieldmapping') {
         setEventMessages($langs->trans('BrevoFieldMappingSaveError'), null, 'errors');
     }
 } elseif ($action === 'savecategorymapping') {
-    if (!checkToken()) {
+    if (!brevointegration_check_token()) {
         accessforbidden();
     }
 
@@ -280,7 +283,7 @@ if ($action === 'savefieldmapping') {
         setEventMessages($langs->trans('BrevoCategoryMappingSaveError'), null, 'errors');
     }
 } elseif ($action === 'generatepatch') {
-    if (!checkToken()) {
+    if (!brevointegration_check_token()) {
         accessforbidden();
     }
 
@@ -312,10 +315,10 @@ $head[] = array($baseUrl.'?tab=diagnostic', $langs->trans('BrevoSetupTabDiagnost
 dol_fiche_head($head, $selectedTab, $langs->trans('BrevoSetupTitle'), -1, 'icon-picto-brevo.svg@brevointegration');
 
 if ($selectedTab === 'configuration') {
-    $token = newToken();
-    $testToken = newToken();
-    $mappingToken = newToken();
-    $categoryToken = newToken();
+    $token = brevointegration_new_token();
+    $testToken = brevointegration_new_token();
+    $mappingToken = brevointegration_new_token();
+    $categoryToken = brevointegration_new_token();
     $contactMapping = $mappingService->getMappingForType('contact');
     $thirdpartyMapping = $mappingService->getMappingForType('thirdparty');
     $contactMapping[] = array('attribute' => '', 'source' => '', 'field' => '');
@@ -880,7 +883,7 @@ if ($selectedTab === 'configuration') {
 
     $patchNeeded = (!$logStatus['ready'] || !$contactStatus['ready']);
     if ($patchNeeded) {
-        $patchToken = newToken();
+        $patchToken = brevointegration_new_token();
         print '<form action="'.dol_escape_htmltag($_SERVER['PHP_SELF']).'" method="post" class="mtop25">';
         print '    <input type="hidden" name="token" value="'.$patchToken.'" />';
         print '    <input type="hidden" name="action" value="generatepatch" />';

--- a/htdocs/custom/brevointegration/class/actions_brevointegration.class.php
+++ b/htdocs/custom/brevointegration/class/actions_brevointegration.class.php
@@ -17,6 +17,7 @@ dol_include_once('/brevointegration/class/BrevoClient.class.php');
 dol_include_once('/brevointegration/class/brevosync.class.php');
 dol_include_once('/brevointegration/class/services/brevofieldmappingservice.class.php');
 dol_include_once('/brevointegration/class/services/brevocategorymappingservice.class.php');
+dol_include_once('/brevointegration/lib/brevointegration_security.lib.php');
 
 /**
  * Class ActionsBrevointegration
@@ -63,7 +64,7 @@ class ActionsBrevointegration
             return 0;
         }
 
-        if (!checkToken()) {
+        if (!brevointegration_check_token()) {
             setEventMessages($langs->trans('ErrorBadToken'), null, 'errors');
             return -1;
         }

--- a/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
@@ -32,7 +32,7 @@ class modBrevointegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.12';
+        $this->version = '1.3.13';
         $this->const_name = 'BREVO_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';

--- a/htdocs/custom/brevointegration/lib/brevointegration_security.lib.php
+++ b/htdocs/custom/brevointegration/lib/brevointegration_security.lib.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package   brevointegration
+ * @author    Meditrust
+ * @license   GPL-3.0-or-later
+ * @brief     Security helpers to ensure CSRF protection works even when Dolibarr token helpers are unavailable.
+ */
+
+if (!function_exists('brevointegration_require_security_libs')) {
+    /**
+     * Ensure Dolibarr security libraries are loaded when available.
+     *
+     * @return void
+     */
+    function brevointegration_require_security_libs(): void
+    {
+        if (!defined('DOL_DOCUMENT_ROOT')) {
+            return;
+        }
+
+        if (!function_exists('newToken')) {
+            $functionsPath = DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
+            if (file_exists($functionsPath)) {
+                require_once $functionsPath;
+            } else {
+                brevointegration_log_security_issue('Missing functions.lib.php to provide newToken().');
+            }
+        }
+
+        if (!function_exists('checkToken')) {
+            $securityPath = DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
+            if (file_exists($securityPath)) {
+                require_once $securityPath;
+            } else {
+                brevointegration_log_security_issue('Missing security.lib.php to provide checkToken().');
+            }
+        }
+    }
+}
+
+if (!function_exists('brevointegration_log_security_issue')) {
+    /**
+     * Log a warning without triggering fatal errors when Dolibarr helpers are unavailable.
+     *
+     * @param string $message Message to log
+     * @return void
+     */
+    function brevointegration_log_security_issue(string $message): void
+    {
+        if (function_exists('dol_syslog')) {
+            $level = defined('LOG_WARNING') ? LOG_WARNING : 4;
+            dol_syslog(__FILE__.' '.$message, $level);
+        } else {
+            error_log('[brevointegration] '.$message);
+        }
+    }
+}
+
+if (!function_exists('brevointegration_new_token')) {
+    /**
+     * Generate a CSRF token using Dolibarr helper when available, otherwise fallback to a local implementation.
+     *
+     * @return string
+     */
+    function brevointegration_new_token(): string
+    {
+        brevointegration_require_security_libs();
+
+        if (function_exists('newToken')) {
+            return (string) newToken();
+        }
+
+        brevointegration_log_security_issue('Fallback new token generator used because newToken() is unavailable.');
+
+        $token = '';
+        try {
+            $token = bin2hex(random_bytes(16));
+        } catch (Throwable $exception) {
+            $token = sha1((string) mt_rand().microtime(true));
+        }
+
+        if (!isset($_SESSION)) {
+            $_SESSION = array();
+        }
+
+        if (!isset($_SESSION['brevointegration_token_pool']) || !is_array($_SESSION['brevointegration_token_pool'])) {
+            $_SESSION['brevointegration_token_pool'] = array();
+        }
+
+        $_SESSION['brevointegration_token_pool'][] = $token;
+        if (count($_SESSION['brevointegration_token_pool']) > 20) {
+            array_shift($_SESSION['brevointegration_token_pool']);
+        }
+
+        $_SESSION['newtoken'] = $token;
+
+        return $token;
+    }
+}
+
+if (!function_exists('brevointegration_check_token')) {
+    /**
+     * Validate a CSRF token using Dolibarr helper when available, otherwise fallback to a local implementation.
+     *
+     * @return bool
+     */
+    function brevointegration_check_token(): bool
+    {
+        brevointegration_require_security_libs();
+
+        if (function_exists('checkToken')) {
+            return (bool) checkToken();
+        }
+
+        brevointegration_log_security_issue('Fallback token validator used because checkToken() is unavailable.');
+
+        $token = '';
+        if (function_exists('GETPOST')) {
+            $token = (string) GETPOST('token', 'alphanohtml');
+        } elseif (isset($_POST['token'])) {
+            $token = (string) $_POST['token'];
+        } elseif (isset($_GET['token'])) {
+            $token = (string) $_GET['token'];
+        }
+
+        if ($token === '') {
+            return false;
+        }
+
+        $sessionToken = isset($_SESSION['newtoken']) ? (string) $_SESSION['newtoken'] : '';
+        $pool = isset($_SESSION['brevointegration_token_pool']) && is_array($_SESSION['brevointegration_token_pool']) ? $_SESSION['brevointegration_token_pool'] : array();
+
+        $candidates = $pool;
+        if ($sessionToken !== '') {
+            $candidates[] = $sessionToken;
+        }
+
+        foreach ($candidates as $index => $candidate) {
+            $candidate = (string) $candidate;
+            if ($candidate === '') {
+                continue;
+            }
+
+            $isValid = function_exists('hash_equals') ? hash_equals($candidate, $token) : ($candidate === $token);
+            if ($isValid) {
+                if (isset($_SESSION['brevointegration_token_pool'][$index])) {
+                    unset($_SESSION['brevointegration_token_pool'][$index]);
+                    $_SESSION['brevointegration_token_pool'] = array_values($_SESSION['brevointegration_token_pool']);
+                }
+
+                if ($sessionToken === $candidate) {
+                    $_SESSION['newtoken'] = $candidate;
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/htdocs/custom/brevointegration/tpl/contact_brevointegration.tpl.php
+++ b/htdocs/custom/brevointegration/tpl/contact_brevointegration.tpl.php
@@ -12,9 +12,11 @@ if (!defined('DOL_DOCUMENT_ROOT')) {
     exit;
 }
 
+dol_include_once('/brevointegration/lib/brevointegration_security.lib.php');
+
 /** @var Form $form */
 $form = isset($form) ? $form : null;
-$token = newToken();
+$token = brevointegration_new_token();
 $cardUrl = $_SERVER['PHP_SELF'];
 if (in_array('thirdpartycard', $context)) {
     $cardUrl .= '?socid='.(int) $object->id;


### PR DESCRIPTION
## Summary
- add a Brevo security helper that loads Dolibarr token libraries when available and provides a CSRF fallback when they are not
- update the admin setup page, card hooks, and UI template to rely on the resilient token helper to avoid 500 errors during form submissions
- bump the module version/documentation and log the regression in the collaborative bug tracker

## Testing
- php -l htdocs/custom/brevointegration/lib/brevointegration_security.lib.php
- php -l htdocs/custom/brevointegration/admin/setup.php
- php -l htdocs/custom/brevointegration/class/actions_brevointegration.class.php
- php -l htdocs/custom/brevointegration/tpl/contact_brevointegration.tpl.php

------
https://chatgpt.com/codex/tasks/task_e_68d828195f588320bb94878e9800c46e