### PR TITLE
Fix Brevo module deactivation constant

### DIFF
--- a/BUG_TRACKER_COLLABORATIF.md
+++ b/BUG_TRACKER_COLLABORATIF.md
@@ -116,3 +116,19 @@
     - Résultat : Toujours en échec lorsque l'hébergeur bloque l'inclusion (fichier absent ou chemin filtré).
 - **Solution retenue / correctif appliqué** : Création d'un helper `brevointegration_security.lib.php` qui tente de charger les bibliothèques natives et fournit un repli CSRF contrôlé (journalisation + génération/validation locale) pour éviter l'erreur 500.
 - **Statut actuel** : corrigé
+
+### BUG-2025-10-16-DISABLE-CONST
+- **ID du bug** : BUG-2025-10-16-DISABLE-CONST
+- **Description** : Impossible de désactiver le module depuis la liste des modules Dolibarr, le curseur revient immédiatement à « activé ».
+- **Date de détection** : 2025-10-16
+- **Étapes pour reproduire** :
+  1. Aller sur `setup/modules.php`.
+  2. Cliquer sur l'interrupteur de désactivation du module Brevo Integration.
+  3. Constater que l'interrupteur revient à l'état activé après rechargement.
+- **Solutions déjà testées** :
+  - Tentative 1 : Vidage du cache navigateur et rechargement de la page.
+    - Résultat : Aucun effet, le module reste activé.
+  - Tentative 2 : Suppression manuelle de la constante `BREVO_MODULE_BREVOINTEGRATION`.
+    - Résultat : Le module se réactive automatiquement car Dolibarr s'appuie sur `MAIN_MODULE_BREVOINTEGRATION` pour gérer l'état.
+- **Solution retenue / correctif appliqué** : Harmonisation de la constante `$this->const_name` du descripteur pour qu'elle corresponde à `MAIN_MODULE_BREVOINTEGRATION`, ce qui aligne le module sur le mécanisme standard d'activation/désactivation Dolibarr.
+- **Statut actuel** : corrigé

--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.3.14] - 2025-10-16
+### Fixed
+- Restaure la constante `MAIN_MODULE_BREVOINTEGRATION` dans le descripteur afin de permettre la désactivation du module depuis l'administration Dolibarr.
+
 ## [1.3.13] - 2025-10-15
 ### Fixed
 - Ajout d'un helper de sécurité dédié pour charger automatiquement les bibliothèques Dolibarr et fournir un repli CSRF afin d'éviter l'erreur fatale « Call to undefined function checkToken() ».

--- a/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
@@ -32,8 +32,8 @@ class modBrevointegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.13';
-        $this->const_name = 'BREVO_MODULE_'.strtoupper($this->name);
+        $this->version = '1.3.14';
+        $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';
 


### PR DESCRIPTION
## Summary
- align the module descriptor with the standard MAIN_MODULE constant so the module can be disabled
- bump the Brevo Integration version to 1.3.14 and document the fix in the changelog
- record the regression and its resolution in the collaborative bug tracker

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d82ccaaa9883209149ffef07bd5909