### PR TITLE
Add dedicated logging for Brevo admin logs page

### DIFF
--- a/BUG_TRACKER_COLLABORATIF.md
+++ b/BUG_TRACKER_COLLABORATIF.md
@@ -117,6 +117,20 @@
 - **Solution retenue / correctif appliqué** : Création d'un helper `brevointegration_security.lib.php` qui tente de charger les bibliothèques natives et fournit un repli CSRF contrôlé (journalisation + génération/validation locale) pour éviter l'erreur 500.
 - **Statut actuel** : corrigé
 
+### BUG-2025-10-18-LOGS-NO-TRACE
+- **ID du bug** : BUG-2025-10-18-LOGS-NO-TRACE
+- **Description** : La page `custom/brevointegration/admin/logs.php` renvoie une erreur 500 silencieuse lorsque la requête SQL échoue, sans trace dans `dolibarr.log`.
+- **Date de détection** : 2025-10-18
+- **Étapes pour reproduire** :
+  1. Accéder à `custom/brevointegration/admin/logs.php` sur un environnement où la table `llx_brevo_log` est présente mais où l'accès SQL échoue (droits insuffisants, schéma incomplet).
+  2. Constater l'erreur HTTP 500.
+  3. Vérifier l'absence de trace exploitable dans `dolibarr.log`.
+- **Solutions déjà testées** :
+  - Tentative 1 : S'appuyer uniquement sur `dol_syslog()` pour les erreurs SQL.
+    - Résultat : Aucune trace lorsque PHP plante avant la journalisation centrale.
+- **Solution retenue / correctif appliqué** : Création d'un logger dédié `brevo_admin.log` avec enregistrement systématique des requêtes et encapsulation de la page dans un `try/catch` pour afficher un message contrôlé.
+- **Statut actuel** : corrigé
+
 ### BUG-2025-10-16-DISABLE-CONST
 - **ID du bug** : BUG-2025-10-16-DISABLE-CONST
 - **Description** : Impossible de désactiver le module depuis la liste des modules Dolibarr, le curseur revient immédiatement à « activé ».

--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.3.16] - 2025-10-18
+### Added
+- Ajout d'un logger dédié `brevo_admin.log` pour tracer chaque accès et les erreurs SQL de la page `admin/logs.php` avec un identifiant de requête.
+### Changed
+- Encadrement de la page d'administration des journaux dans un bloc `try/catch` pour consigner les exceptions et afficher un message d'erreur contrôlé au lieu d'une erreur 500.
+
 ## [1.3.15] - 2025-10-17
 ### Fixed
 - Empêche l'enregistrement d'une clé API Brevo invalide en vérifiant la connexion avant de sauvegarder et en journalisant l'appel.

--- a/htdocs/custom/brevointegration/admin/logs.php
+++ b/htdocs/custom/brevointegration/admin/logs.php
@@ -16,6 +16,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/list.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 dol_include_once('/brevointegration/class/services/brevologservice.class.php');
 dol_include_once('/brevointegration/lib/brevointegration_date.lib.php');
+dol_include_once('/brevointegration/lib/brevointegration_logger.lib.php');
 
 /**
  * Build a timestamp using Dolibarr helper when available, otherwise fallback to PHP's mktime.
@@ -46,252 +47,317 @@ function brevointegrationBuildTimestamp($hour, $minute, $second, $month, $day, $
 
 global $langs, $user, $conf, $db;
 
+$brevoLogsRequestId = uniqid('brevo_logs_', true);
+$httpContext = array(
+    'request_id' => $brevoLogsRequestId,
+    'method' => isset($_SERVER['REQUEST_METHOD']) ? (string) $_SERVER['REQUEST_METHOD'] : 'CLI',
+    'uri' => isset($_SERVER['REQUEST_URI']) ? (string) $_SERVER['REQUEST_URI'] : 'unknown',
+    'remote_ip' => isset($_SERVER['REMOTE_ADDR']) ? (string) $_SERVER['REMOTE_ADDR'] : 'unknown',
+);
+
+brevointegration_logger_info('logs.php bootstrap', $httpContext + array(
+    'user_id' => isset($user->id) ? (int) $user->id : 0,
+    'query' => isset($_GET) && is_array($_GET) ? $_GET : array(),
+));
+
 if (!$user->admin) {
+    brevointegration_logger_error('logs.php forbidden access', $httpContext + array('user_id' => isset($user->id) ? (int) $user->id : 0));
     accessforbidden();
 }
 
-$langs->load('admin');
-$langs->load('brevointegration@brevointegration');
+$layoutStarted = false;
 
-$form = new Form($db);
-$logService = new BrevoLogService($db, $conf);
-$storageStatus = $logService->getLogStorageStatus();
-$storageReady = !empty($storageStatus['exists']) && !empty($storageStatus['ready']);
+try {
+    $langs->load('admin');
+    $langs->load('brevointegration@brevointegration');
 
-$now = dol_now();
-$defaultStart = $now - (7 * 24 * 3600);
-$defaultEnd = $now;
+    $form = new Form($db);
+    $logService = new BrevoLogService($db, $conf);
 
-$resetFilter = GETPOST('button_removefilter', 'alpha');
+    $storageStatus = $logService->getLogStorageStatus();
+    $storageReady = !empty($storageStatus['exists']) && !empty($storageStatus['ready']);
 
-$startTimestamp = $defaultStart;
-$endTimestamp = $defaultEnd;
+    brevointegration_logger_debug('logs.php storage status', $httpContext + array('status' => $storageStatus));
 
-if (!$resetFilter) {
-    $startTimestamp = brevointegrationBuildTimestamp(
-        0,
-        0,
-        0,
-        GETPOST('filter_startmonth', 'int'),
-        GETPOST('filter_startday', 'int'),
-        GETPOST('filter_startyear', 'int')
+    $now = dol_now();
+    $defaultStart = $now - (7 * 24 * 3600);
+    $defaultEnd = $now;
+
+    $resetFilter = GETPOST('button_removefilter', 'alpha');
+
+    $startTimestamp = $defaultStart;
+    $endTimestamp = $defaultEnd;
+
+    if (!$resetFilter) {
+        $startTimestamp = brevointegrationBuildTimestamp(
+            0,
+            0,
+            0,
+            GETPOST('filter_startmonth', 'int'),
+            GETPOST('filter_startday', 'int'),
+            GETPOST('filter_startyear', 'int')
+        );
+        $endTimestamp = brevointegrationBuildTimestamp(
+            23,
+            59,
+            59,
+            GETPOST('filter_endmonth', 'int'),
+            GETPOST('filter_endday', 'int'),
+            GETPOST('filter_endyear', 'int')
+        );
+
+        if ($startTimestamp <= 0) {
+            $startTimestamp = $defaultStart;
+        }
+        if ($endTimestamp <= 0) {
+            $endTimestamp = $defaultEnd;
+        }
+    }
+
+    $limitInput = (int) GETPOST('limit', 'int');
+    if ($limitInput <= 0) {
+        $limitInput = isset($conf->liste_limit) ? (int) $conf->liste_limit : 50;
+    }
+    $limit = max(10, min(100, $limitInput));
+
+    $page = GETPOST('page', 'int');
+    if ($page === '' || $page < 0) {
+        $page = 0;
+    }
+    $offset = $limit * $page;
+
+    $allowedSortfields = array(
+        'date_event' => 'date_event',
+        'method' => 'method',
+        'http_code' => 'http_code',
+        'duration_ms' => 'duration_ms',
+        'success' => 'success',
     );
-    $endTimestamp = brevointegrationBuildTimestamp(
-        23,
-        59,
-        59,
-        GETPOST('filter_endmonth', 'int'),
-        GETPOST('filter_endday', 'int'),
-        GETPOST('filter_endyear', 'int')
-    );
-
-    if ($startTimestamp <= 0) {
-        $startTimestamp = $defaultStart;
+    $sortfield = GETPOST('sortfield', 'aZ09');
+    if (!isset($allowedSortfields[$sortfield])) {
+        $sortfield = 'date_event';
     }
-    if ($endTimestamp <= 0) {
-        $endTimestamp = $defaultEnd;
+    $sortorder = GETPOST('sortorder', 'alpha');
+    $sortorder = strtolower((string) $sortorder) === 'asc' ? 'ASC' : 'DESC';
+
+    $logs = array();
+    $total = 0;
+    $param = '';
+    $selfUrl = isset($_SERVER['PHP_SELF']) ? (string) $_SERVER['PHP_SELF'] : '';
+
+    if ($startTimestamp) {
+        $param .= '&filter_startday='.date('d', $startTimestamp);
+        $param .= '&filter_startmonth='.date('m', $startTimestamp);
+        $param .= '&filter_startyear='.date('Y', $startTimestamp);
     }
-}
+    if ($endTimestamp) {
+        $param .= '&filter_endday='.date('d', $endTimestamp);
+        $param .= '&filter_endmonth='.date('m', $endTimestamp);
+        $param .= '&filter_endyear='.date('Y', $endTimestamp);
+    }
+    if ($limit) {
+        $param .= '&limit='.$limit;
+    }
 
-$limitInput = (int) GETPOST('limit', 'int');
-if ($limitInput <= 0) {
-    $limitInput = isset($conf->liste_limit) ? (int) $conf->liste_limit : 50;
-}
-$limit = max(10, min(100, $limitInput));
-
-$page = GETPOST('page', 'int');
-if ($page === '' || $page < 0) {
-    $page = 0;
-}
-$offset = $limit * $page;
-
-$allowedSortfields = array(
-    'date_event' => 'date_event',
-    'method' => 'method',
-    'http_code' => 'http_code',
-    'duration_ms' => 'duration_ms',
-    'success' => 'success',
-);
-$sortfield = GETPOST('sortfield', 'aZ09');
-if (!isset($allowedSortfields[$sortfield])) {
-    $sortfield = 'date_event';
-}
-$sortorder = GETPOST('sortorder', 'alpha');
-$sortorder = strtolower((string) $sortorder) === 'asc' ? 'ASC' : 'DESC';
-
-$logs = array();
-$total = 0;
-$param = '';
-
-if ($startTimestamp) {
-    $param .= '&filter_startday='.date('d', $startTimestamp);
-    $param .= '&filter_startmonth='.date('m', $startTimestamp);
-    $param .= '&filter_startyear='.date('Y', $startTimestamp);
-}
-if ($endTimestamp) {
-    $param .= '&filter_endday='.date('d', $endTimestamp);
-    $param .= '&filter_endmonth='.date('m', $endTimestamp);
-    $param .= '&filter_endyear='.date('Y', $endTimestamp);
-}
-if ($limit) {
-    $param .= '&limit='.$limit;
-}
-
-if (!$storageStatus['exists']) {
-    setEventMessages($langs->trans('BrevoLogsStorageMissingTable', dol_escape_htmltag($storageStatus['table_name'])), null, 'warnings');
-} elseif (!$storageStatus['ready']) {
-    $missingColumns = array();
-    if (!empty($storageStatus['missing_columns'])) {
-        if (is_array($storageStatus['missing_columns'])) {
-            $missingColumns = array_map('dol_escape_htmltag', $storageStatus['missing_columns']);
-        } else {
-            dol_syslog(__FILE__.' unexpected missing_columns payload type: '.gettype($storageStatus['missing_columns']), LOG_ERR);
-            $missingColumns = array(dol_escape_htmltag((string) $storageStatus['missing_columns']));
+    if (!$storageStatus['exists']) {
+        brevointegration_logger_error('logs.php missing table', $httpContext + array('status' => $storageStatus, 'self' => $selfUrl));
+        setEventMessages($langs->trans('BrevoLogsStorageMissingTable', dol_escape_htmltag($storageStatus['table_name'])), null, 'warnings');
+    } elseif (!$storageStatus['ready']) {
+        $missingColumns = array();
+        if (!empty($storageStatus['missing_columns'])) {
+            if (is_array($storageStatus['missing_columns'])) {
+                $missingColumns = array_map('dol_escape_htmltag', $storageStatus['missing_columns']);
+            } else {
+                dol_syslog(__FILE__.' unexpected missing_columns payload type: '.gettype($storageStatus['missing_columns']), LOG_ERR);
+                $missingColumns = array(dol_escape_htmltag((string) $storageStatus['missing_columns']));
+            }
         }
-    }
-    $missingList = !empty($missingColumns) ? implode(', ', $missingColumns) : dol_escape_htmltag($langs->trans('Unknown'));
-    setEventMessages($langs->trans('BrevoLogsStorageMissingColumns', $missingList), null, 'warnings');
-} else {
-    $conditions = array('entity = '.((int) $conf->entity));
-
-    if ($startTimestamp > 0) {
-        $startSql = brevointegration_format_sql_datetime($db, $startTimestamp);
-        if ($startSql !== null) {
-            $conditions[] = 'date_event >= '.$startSql;
-        }
-    }
-    if ($endTimestamp > 0) {
-        $endSql = brevointegration_format_sql_datetime($db, $endTimestamp);
-        if ($endSql !== null) {
-            $conditions[] = 'date_event <= '.$endSql;
-        }
-    }
-
-    $whereClause = implode(' AND ', $conditions);
-
-    $countSql = 'SELECT COUNT(*) as total FROM '.MAIN_DB_PREFIX.'brevo_log WHERE '.$whereClause;
-    $resCount = $db->query($countSql);
-    if ($resCount === false) {
-        dol_syslog(__FILE__.'::count_logs '.$db->lasterror(), LOG_ERR);
-        setEventMessages($langs->trans('ErrorInternalError'), null, 'errors');
+        $missingList = !empty($missingColumns) ? implode(', ', $missingColumns) : dol_escape_htmltag($langs->trans('Unknown'));
+        brevointegration_logger_error('logs.php incomplete table schema', $httpContext + array('missing' => $missingColumns, 'self' => $selfUrl));
+        setEventMessages($langs->trans('BrevoLogsStorageMissingColumns', $missingList), null, 'warnings');
     } else {
-        $countObj = $db->fetch_object($resCount);
-        $total = $countObj ? (int) $countObj->total : 0;
-        if (method_exists($db, 'free')) {
-            $db->free($resCount);
+        $conditions = array('entity = '.((int) $conf->entity));
+
+        if ($startTimestamp > 0) {
+            $startSql = brevointegration_format_sql_datetime($db, $startTimestamp);
+            if ($startSql !== null) {
+                $conditions[] = 'date_event >= '.$startSql;
+            }
+        }
+        if ($endTimestamp > 0) {
+            $endSql = brevointegration_format_sql_datetime($db, $endTimestamp);
+            if ($endSql !== null) {
+                $conditions[] = 'date_event <= '.$endSql;
+            }
         }
 
-        $sql = 'SELECT rowid, date_event, method, endpoint, http_code, duration_ms, success, message FROM '.MAIN_DB_PREFIX.'brevo_log';
-        $sql .= ' WHERE '.$whereClause;
-        $sql .= ' ORDER BY '.$allowedSortfields[$sortfield].' '.$sortorder;
-        $sql .= $db->plimit($limit, $offset);
+        $whereClause = implode(' AND ', $conditions);
 
-        $resql = $db->query($sql);
-        if ($resql === false) {
-            dol_syslog(__FILE__.'::select_logs '.$db->lasterror(), LOG_ERR);
+        $countSql = 'SELECT COUNT(*) as total FROM '.MAIN_DB_PREFIX.'brevo_log WHERE '.$whereClause;
+        brevointegration_logger_debug('logs.php count query', $httpContext + array('sql' => $countSql, 'self' => $selfUrl));
+        $resCount = $db->query($countSql);
+        if ($resCount === false) {
+            $errorMessage = $db->lasterror();
+            brevointegration_logger_error('logs.php count query failed', $httpContext + array('sql' => $countSql, 'error' => $errorMessage, 'self' => $selfUrl));
+            dol_syslog(__FILE__.'::count_logs '.$errorMessage, LOG_ERR);
             setEventMessages($langs->trans('ErrorInternalError'), null, 'errors');
         } else {
-            while ($obj = $db->fetch_object($resql)) {
-                $logs[] = array(
-                    'rowid' => isset($obj->rowid) ? (int) $obj->rowid : 0,
-                    'date_event' => isset($obj->date_event) ? (int) (method_exists($db, 'jdate') ? $db->jdate($obj->date_event) : strtotime((string) $obj->date_event)) : 0,
-                    'method' => isset($obj->method) ? (string) $obj->method : '',
-                    'endpoint' => isset($obj->endpoint) ? (string) $obj->endpoint : '',
-                    'http_code' => isset($obj->http_code) ? (int) $obj->http_code : 0,
-                    'duration_ms' => isset($obj->duration_ms) ? (int) $obj->duration_ms : 0,
-                    'success' => !empty($obj->success) ? 1 : 0,
-                    'message' => isset($obj->message) ? (string) $obj->message : '',
-                );
-            }
+            $countObj = $db->fetch_object($resCount);
+            $total = $countObj ? (int) $countObj->total : 0;
             if (method_exists($db, 'free')) {
-                $db->free($resql);
+                $db->free($resCount);
+            }
+
+            $sql = 'SELECT rowid, date_event, method, endpoint, http_code, duration_ms, success, message FROM '.MAIN_DB_PREFIX.'brevo_log';
+            $sql .= ' WHERE '.$whereClause;
+            $sql .= ' ORDER BY '.$allowedSortfields[$sortfield].' '.$sortorder;
+            $sql .= $db->plimit($limit, $offset);
+
+            brevointegration_logger_debug('logs.php select query', $httpContext + array('sql' => $sql, 'limit' => $limit, 'offset' => $offset, 'self' => $selfUrl));
+            $resql = $db->query($sql);
+            if ($resql === false) {
+                $errorMessage = $db->lasterror();
+                brevointegration_logger_error('logs.php select query failed', $httpContext + array('sql' => $sql, 'error' => $errorMessage, 'self' => $selfUrl));
+                dol_syslog(__FILE__.'::select_logs '.$errorMessage, LOG_ERR);
+                setEventMessages($langs->trans('ErrorInternalError'), null, 'errors');
+            } else {
+                while ($obj = $db->fetch_object($resql)) {
+                    $logs[] = array(
+                        'rowid' => isset($obj->rowid) ? (int) $obj->rowid : 0,
+                        'date_event' => isset($obj->date_event) ? (int) (method_exists($db, 'jdate') ? $db->jdate($obj->date_event) : strtotime((string) $obj->date_event)) : 0,
+                        'method' => isset($obj->method) ? (string) $obj->method : '',
+                        'endpoint' => isset($obj->endpoint) ? (string) $obj->endpoint : '',
+                        'http_code' => isset($obj->http_code) ? (int) $obj->http_code : 0,
+                        'duration_ms' => isset($obj->duration_ms) ? (int) $obj->duration_ms : 0,
+                        'success' => !empty($obj->success) ? 1 : 0,
+                        'message' => isset($obj->message) ? (string) $obj->message : '',
+                    );
+                }
+                if (method_exists($db, 'free')) {
+                    $db->free($resql);
+                }
             }
         }
     }
-}
 
-llxHeader('', $langs->trans('BrevoLogsTitle'));
+    llxHeader('', $langs->trans('BrevoLogsTitle'));
+    $layoutStarted = true;
 
-$linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php">'.$langs->trans('BackToModuleList').'</a>';
-print load_fiche_titre($langs->trans('BrevoLogsTitle'), $linkback, 'icon-picto-brevo.svg@brevointegration');
-print '<p class="opacitymedium">'.$langs->trans('BrevoLogsIntro').'</p>';
+    $linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php">'.$langs->trans('BackToModuleList').'</a>';
+    print load_fiche_titre($langs->trans('BrevoLogsTitle'), $linkback, 'icon-picto-brevo.svg@brevointegration');
+    print '<p class="opacitymedium">'.$langs->trans('BrevoLogsIntro').'</p>';
 
-if ($storageReady) {
-    print '<form method="GET" action="'.dol_escape_htmltag($_SERVER['PHP_SELF']).'" class="filter">';
-    print '<table class="noborder" width="100%">';
-    print '<tr class="liste_titre">';
-    print '<th>'.$langs->trans('BrevoLogsFilterPeriod').'</th>';
-    print '<th class="right">'.$langs->trans('Actions').'</th>';
-    print '</tr>';
-    print '<tr class="oddeven">';
-    print '<td>';
-    print '<div class="inline-block">';
-    print '<label class="marginrightonly" for="filter_startday">'.$langs->trans('BrevoLogsFilterStart').'</label>';
-    print $form->selectDate($startTimestamp, 'filter_start', 0, 0, 1, '', 1, 1);
-    print '</div>';
-    print '<div class="inline-block margintoponly">';
-    print '<label class="marginrightonly" for="filter_endday">'.$langs->trans('BrevoLogsFilterEnd').'</label>';
-    print $form->selectDate($endTimestamp, 'filter_end', 0, 0, 1, '', 1, 1);
-    print '</div>';
-    print '</td>';
-    print '<td class="right">';
-    print '<input type="submit" class="button" value="'.dol_escape_htmltag($langs->trans('BrevoLogsFilterSubmit')).'" />';
-    print ' ';
-    print '<input type="submit" class="button button-cancel" name="button_removefilter" value="'.dol_escape_htmltag($langs->trans('Reset')).'" />';
-    print '</td>';
-    print '</tr>';
-    print '</table>';
-    print '</form>';
+    brevointegration_logger_info('logs.php rendering list', $httpContext + array(
+        'storage_ready' => $storageReady,
+        'total' => $total,
+        'displayed' => count($logs),
+        'page' => $page,
+        'limit' => $limit,
+        'sortfield' => $sortfield,
+        'sortorder' => $sortorder,
+        'self' => $selfUrl,
+    ));
 
-    print_barre_liste(
-        $langs->trans('BrevoLogsListTitle'),
-        $page,
-        $_SERVER['PHP_SELF'],
-        $param,
-        $sortfield,
-        $sortorder,
-        '',
-        $total,
-        $limit
-    );
-
-    print '<div class="div-table-responsive">';
-    print '<table class="noborder tagtable liste">';
-    print '<tr class="liste_titre">';
-    print_liste_field_titre($langs->trans('BrevoLogsDate'), $_SERVER['PHP_SELF'], 'date_event', '', $param, '', $sortfield, $sortorder);
-    print_liste_field_titre($langs->trans('BrevoLogsMethod'), $_SERVER['PHP_SELF'], 'method', '', $param, '', $sortfield, $sortorder);
-    print_liste_field_titre($langs->trans('BrevoLogsEndpoint'), $_SERVER['PHP_SELF'], 'endpoint', '', $param, '', $sortfield, $sortorder);
-    print_liste_field_titre($langs->trans('BrevoLogsStatus'), $_SERVER['PHP_SELF'], 'http_code', '', $param, '', $sortfield, $sortorder, 'right');
-    print_liste_field_titre($langs->trans('BrevoLogsDuration'), $_SERVER['PHP_SELF'], 'duration_ms', '', $param, '', $sortfield, $sortorder, 'right');
-    print '<th class="left">'.$langs->trans('BrevoLogsMessage').'</th>';
-    print '</tr>';
-
-    if (empty($logs)) {
-        $colspan = 6;
-        print '<tr class="oddeven">';
-        print '<td class="center" colspan="'.$colspan.'">'.$langs->trans('BrevoLogsEmpty').'</td>';
+    if ($storageReady) {
+        print '<form method="GET" action="'.dol_escape_htmltag($selfUrl).'" class="filter">';
+        print '<table class="noborder" width="100%">';
+        print '<tr class="liste_titre">';
+        print '<th>'.$langs->trans('BrevoLogsFilterPeriod').'</th>';
+        print '<th class="right">'.$langs->trans('Actions').'</th>';
         print '</tr>';
-    } else {
-        foreach ($logs as $log) {
-            $class = empty($log['success']) ? 'error' : '';
-            print '<tr class="oddeven'.($class !== '' ? ' '.$class : '').'">';
-            print '<td>'.dol_print_date($log['date_event'], 'dayhour').'</td>';
-            print '<td>'.dol_escape_htmltag($log['method']).'</td>';
-            print '<td>'.dol_escape_htmltag($log['endpoint']).'</td>';
-            print '<td class="right">'.dol_escape_htmltag((string) $log['http_code']).'</td>';
-            $durationLabel = sprintf($langs->trans('BrevoLogsDurationUnit'), (int) $log['duration_ms']);
-            print '<td class="right">'.dol_escape_htmltag($durationLabel).'</td>';
-            $message = $log['message'] !== '' ? dol_escape_htmltag($log['message']) : '&nbsp;';
-            print '<td>'.$message.'</td>';
+        print '<tr class="oddeven">';
+        print '<td>';
+        print '<div class="inline-block">';
+        print '<label class="marginrightonly" for="filter_startday">'.$langs->trans('BrevoLogsFilterStart').'</label>';
+        print $form->selectDate($startTimestamp, 'filter_start', 0, 0, 1, '', 1, 1);
+        print '</div>';
+        print '<div class="inline-block margintoponly">';
+        print '<label class="marginrightonly" for="filter_endday">'.$langs->trans('BrevoLogsFilterEnd').'</label>';
+        print $form->selectDate($endTimestamp, 'filter_end', 0, 0, 1, '', 1, 1);
+        print '</div>';
+        print '</td>';
+        print '<td class="right">';
+        print '<input type="submit" class="button" value="'.dol_escape_htmltag($langs->trans('BrevoLogsFilterSubmit')).'" />';
+        print ' ';
+        print '<input type="submit" class="button button-cancel" name="button_removefilter" value="'.dol_escape_htmltag($langs->trans('Reset')).'" />';
+        print '</td>';
+        print '</tr>';
+        print '</table>';
+        print '</form>';
+
+        print_barre_liste(
+            $langs->trans('BrevoLogsListTitle'),
+            $page,
+            $selfUrl,
+            $param,
+            $sortfield,
+            $sortorder,
+            '',
+            $total,
+            $limit
+        );
+
+        print '<div class="div-table-responsive">';
+        print '<table class="noborder tagtable liste">';
+        print '<tr class="liste_titre">';
+        print_liste_field_titre($langs->trans('BrevoLogsDate'), $selfUrl, 'date_event', '', $param, '', $sortfield, $sortorder);
+        print_liste_field_titre($langs->trans('BrevoLogsMethod'), $selfUrl, 'method', '', $param, '', $sortfield, $sortorder);
+        print_liste_field_titre($langs->trans('BrevoLogsEndpoint'), $selfUrl, 'endpoint', '', $param, '', $sortfield, $sortorder);
+        print_liste_field_titre($langs->trans('BrevoLogsStatus'), $selfUrl, 'http_code', '', $param, '', $sortfield, $sortorder, 'right');
+        print_liste_field_titre($langs->trans('BrevoLogsDuration'), $selfUrl, 'duration_ms', '', $param, '', $sortfield, $sortorder, 'right');
+        print '<th class="left">'.$langs->trans('BrevoLogsMessage').'</th>';
+        print '</tr>';
+
+        if (empty($logs)) {
+            $colspan = 6;
+            print '<tr class="oddeven">';
+            print '<td class="center" colspan="'.$colspan.'">'.$langs->trans('BrevoLogsEmpty').'</td>';
             print '</tr>';
+        } else {
+            foreach ($logs as $log) {
+                $class = empty($log['success']) ? 'error' : '';
+                print '<tr class="oddeven'.($class !== '' ? ' '.$class : '').'">';
+                print '<td>'.dol_print_date($log['date_event'], 'dayhour').'</td>';
+                print '<td>'.dol_escape_htmltag($log['method']).'</td>';
+                print '<td>'.dol_escape_htmltag($log['endpoint']).'</td>';
+                print '<td class="right">'.dol_escape_htmltag((string) $log['http_code']).'</td>';
+                $durationLabel = sprintf($langs->trans('BrevoLogsDurationUnit'), (int) $log['duration_ms']);
+                print '<td class="right">'.dol_escape_htmltag($durationLabel).'</td>';
+                $message = $log['message'] !== '' ? dol_escape_htmltag($log['message']) : '&nbsp;';
+                print '<td>'.$message.'</td>';
+                print '</tr>';
+            }
         }
+
+        print '</table>';
+        print '</div>';
+    } else {
+        print '<div class="opacitymedium">'.$langs->trans('BrevoNoLogs').'</div>';
     }
 
-    print '</table>';
-    print '</div>';
-} else {
-    print '<div class="opacitymedium">'.$langs->trans('BrevoNoLogs').'</div>';
-}
+    llxFooter();
+    $layoutStarted = false;
+    $db->close();
 
-llxFooter();
-$db->close();
+    brevointegration_logger_info('logs.php completed', $httpContext + array('status' => 'success', 'total' => $total, 'displayed' => count($logs), 'self' => $selfUrl));
+} catch (Throwable $exception) {
+    brevointegration_logger_error('logs.php fatal exception', $httpContext + array('exception' => $exception, 'self' => isset($selfUrl) ? $selfUrl : ''));
+
+    if (!$layoutStarted) {
+        llxHeader('', $langs->trans('BrevoLogsTitle'));
+        $layoutStarted = true;
+        $linkback = '<a href="'.DOL_URL_ROOT.'/admin/modules.php">'.$langs->trans('BackToModuleList').'</a>';
+        print load_fiche_titre($langs->trans('BrevoLogsTitle'), $linkback, 'icon-picto-brevo.svg@brevointegration');
+    }
+
+    setEventMessages($langs->trans('ErrorInternalError'), null, 'errors');
+    print '<div class="error">'.dol_escape_htmltag($langs->trans('ErrorInternalError')).'</div>';
+
+    if ($layoutStarted) {
+        llxFooter();
+    }
+
+    if (isset($db) && method_exists($db, 'close')) {
+        $db->close();
+    }
+}

--- a/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
@@ -32,7 +32,7 @@ class modBrevointegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.15';
+        $this->version = '1.3.16';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';

--- a/htdocs/custom/brevointegration/lib/brevointegration_logger.lib.php
+++ b/htdocs/custom/brevointegration/lib/brevointegration_logger.lib.php
@@ -1,0 +1,178 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package   brevointegration
+ * @author    Meditrust
+ * @license   GPL-3.0-or-later
+ * @brief     Lightweight file logger dedicated to Brevo admin diagnostics.
+ */
+
+if (!function_exists('brevointegration_logger_get_log_directory')) {
+    /**
+     * Resolve the directory where Brevo diagnostic logs should be stored.
+     *
+     * @return string
+     */
+    function brevointegration_logger_get_log_directory()
+    {
+        $baseDir = '';
+
+        if (defined('DOL_DATA_ROOT')) {
+            $baseDir = rtrim((string) DOL_DATA_ROOT, '/');
+        }
+
+        if ($baseDir === '') {
+            $baseDir = rtrim(sys_get_temp_dir(), '/');
+        }
+
+        $logDir = $baseDir.'/brevointegration';
+
+        if (!function_exists('dol_mkdir')) {
+            if (!is_dir($logDir)) {
+                @mkdir($logDir, 0777, true);
+            }
+
+            return $logDir;
+        }
+
+        if (!is_dir($logDir)) {
+            dol_mkdir($logDir);
+        }
+
+        return $logDir;
+    }
+}
+
+if (!function_exists('brevointegration_logger_get_log_file_path')) {
+    /**
+     * Return the absolute path to the Brevo admin log file.
+     *
+     * @return string
+     */
+    function brevointegration_logger_get_log_file_path()
+    {
+        $directory = brevointegration_logger_get_log_directory();
+        if ($directory === '') {
+            return '';
+        }
+
+        return $directory.'/brevo_admin.log';
+    }
+}
+
+if (!function_exists('brevointegration_logger_write')) {
+    /**
+     * Write an entry to the Brevo admin log file.
+     *
+     * @param string $level   Log level label
+     * @param string $message Message to log
+     * @param array  $context Additional contextual data
+     * @return void
+     */
+    function brevointegration_logger_write($level, $message, array $context = array())
+    {
+        $path = brevointegration_logger_get_log_file_path();
+        if ($path === '') {
+            return;
+        }
+
+        $timestamp = date('Y-m-d H:i:s');
+
+        $contextPart = '';
+        if (!empty($context)) {
+            $contextPart = ' '.brevointegration_logger_encode_context($context);
+        }
+
+        $entry = sprintf('[%s] [%s] %s%s%s', $timestamp, strtoupper((string) $level), (string) $message, $contextPart, PHP_EOL);
+
+        try {
+            file_put_contents($path, $entry, FILE_APPEND | LOCK_EX);
+        } catch (Throwable $exception) {
+            if (function_exists('dol_syslog')) {
+                dol_syslog(__METHOD__.' unable to write log file: '.$exception->getMessage(), LOG_WARNING);
+            }
+        }
+    }
+}
+
+if (!function_exists('brevointegration_logger_encode_context')) {
+    /**
+     * Safely encode context data for the log file.
+     *
+     * @param array $context
+     * @return string
+     */
+    function brevointegration_logger_encode_context(array $context)
+    {
+        $normalized = array();
+        foreach ($context as $key => $value) {
+            if ($value instanceof Throwable) {
+                $normalized[$key] = array(
+                    'type' => get_class($value),
+                    'message' => $value->getMessage(),
+                    'code' => $value->getCode(),
+                    'file' => $value->getFile(),
+                    'line' => $value->getLine(),
+                );
+                continue;
+            }
+
+            if (is_resource($value)) {
+                $normalized[$key] = sprintf('resource(%s)', get_resource_type($value));
+                continue;
+            }
+
+            $normalized[$key] = $value;
+        }
+
+        $json = json_encode($normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($json === false) {
+            return '[context_encoding_error]';
+        }
+
+        return $json;
+    }
+}
+
+if (!function_exists('brevointegration_logger_debug')) {
+    /**
+     * Log a debug level message.
+     *
+     * @param string $message
+     * @param array  $context
+     * @return void
+     */
+    function brevointegration_logger_debug($message, array $context = array())
+    {
+        brevointegration_logger_write('DEBUG', $message, $context);
+    }
+}
+
+if (!function_exists('brevointegration_logger_info')) {
+    /**
+     * Log an info level message.
+     *
+     * @param string $message
+     * @param array  $context
+     * @return void
+     */
+    function brevointegration_logger_info($message, array $context = array())
+    {
+        brevointegration_logger_write('INFO', $message, $context);
+    }
+}
+
+if (!function_exists('brevointegration_logger_error')) {
+    /**
+     * Log an error level message.
+     *
+     * @param string $message
+     * @param array  $context
+     * @return void
+     */
+    function brevointegration_logger_error($message, array $context = array())
+    {
+        brevointegration_logger_write('ERROR', $message, $context);
+    }
+}


### PR DESCRIPTION
## Summary
- wrap `admin/logs.php` execution in defensive logging with a dedicated `brevo_admin.log` file and graceful error handling
- capture SQL failures and request context to expose the root cause of HTTP 500 responses without using `die()` or HTTP 500 headers
- bump the module to version 1.3.16 and document the fix in the changelog and collaborative bug tracker

## Testing
- php -l htdocs/custom/brevointegration/admin/logs.php
- php -l htdocs/custom/brevointegration/lib/brevointegration_logger.lib.php

------
https://chatgpt.com/codex/tasks/task_e_68d82f6b6668832085108d4418026ddc