### PR TITLE
Fix: harden Brevo logs admin error handling

### DIFF
--- a/BUG_TRACKER_COLLABORATIF.md
+++ b/BUG_TRACKER_COLLABORATIF.md
@@ -128,7 +128,7 @@
 - **Solutions déjà testées** :
   - Tentative 1 : S'appuyer uniquement sur `dol_syslog()` pour les erreurs SQL.
     - Résultat : Aucune trace lorsque PHP plante avant la journalisation centrale.
-- **Solution retenue / correctif appliqué** : Création d'un logger dédié `brevo_admin.log` avec enregistrement systématique des requêtes et encapsulation de la page dans un `try/catch` pour afficher un message contrôlé.
+- **Solution retenue / correctif appliqué** : Création d'un logger dédié `brevo_admin.log` avec enregistrement systématique des requêtes, instrumentation complète du cycle de vie (démarrage, SQL, nombre de lignes, statut final) et encapsulation de la page dans un `try/catch`/`finally` pour afficher un message contrôlé (« Erreur SQL » ou « Erreur interne ») sans 500 silencieux.
 - **Statut actuel** : corrigé
 
 ### BUG-2025-10-16-DISABLE-CONST

--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.3.17] - 2025-10-19
+### Changed
+- Ajout d'une journalisation chronologique détaillée sur `admin/logs.php` (démarrage, exécution des requêtes SQL, nombre de lignes récupérées, clôture) dans le fichier `brevo_admin.log`.
+- Harmonisation des messages d'erreur pour afficher explicitement « Erreur SQL » lors d'un échec de requête tout en conservant un rendu Dolibarr.
+- Ajout d'un bloc `finally` pour fermer systématiquement la connexion SQL, tracer le statut final et éviter les erreurs 500 silencieuses.
+
 ## [1.3.16] - 2025-10-18
 ### Added
 - Ajout d'un logger dédié `brevo_admin.log` pour tracer chaque accès et les erreurs SQL de la page `admin/logs.php` avec un identifiant de requête.

--- a/htdocs/custom/brevointegration/admin/logs.php
+++ b/htdocs/custom/brevointegration/admin/logs.php
@@ -55,17 +55,26 @@ $httpContext = array(
     'remote_ip' => isset($_SERVER['REMOTE_ADDR']) ? (string) $_SERVER['REMOTE_ADDR'] : 'unknown',
 );
 
-brevointegration_logger_info('logs.php bootstrap', $httpContext + array(
-    'user_id' => isset($user->id) ? (int) $user->id : 0,
+$currentUserId = isset($user->id) ? (int) $user->id : 0;
+$currentUserLogin = isset($user->login) ? (string) $user->login : '';
+
+$startContext = $httpContext + array(
+    'user_id' => $currentUserId,
+    'user_login' => $currentUserLogin,
     'query' => isset($_GET) && is_array($_GET) ? $_GET : array(),
-));
+);
+
+brevointegration_logger_info('logs.php started by user='.($currentUserLogin !== '' ? $currentUserLogin : (string) $currentUserId), $startContext);
 
 if (!$user->admin) {
-    brevointegration_logger_error('logs.php forbidden access', $httpContext + array('user_id' => isset($user->id) ? (int) $user->id : 0));
+    brevointegration_logger_error('logs.php forbidden access', $httpContext + array('user_id' => $currentUserId, 'user_login' => $currentUserLogin));
     accessforbidden();
 }
 
 $layoutStarted = false;
+$pageStatus = 'success';
+$logsFetched = 0;
+$selfUrl = isset($_SERVER['PHP_SELF']) ? (string) $_SERVER['PHP_SELF'] : '';
 
 try {
     $langs->load('admin');
@@ -143,7 +152,6 @@ try {
     $logs = array();
     $total = 0;
     $param = '';
-    $selfUrl = isset($_SERVER['PHP_SELF']) ? (string) $_SERVER['PHP_SELF'] : '';
 
     if ($startTimestamp) {
         $param .= '&filter_startday='.date('d', $startTimestamp);
@@ -194,13 +202,14 @@ try {
         $whereClause = implode(' AND ', $conditions);
 
         $countSql = 'SELECT COUNT(*) as total FROM '.MAIN_DB_PREFIX.'brevo_log WHERE '.$whereClause;
-        brevointegration_logger_debug('logs.php count query', $httpContext + array('sql' => $countSql, 'self' => $selfUrl));
+        brevointegration_logger_info('Executing SQL (count)', $httpContext + array('sql' => $countSql, 'self' => $selfUrl));
         $resCount = $db->query($countSql);
         if ($resCount === false) {
             $errorMessage = $db->lasterror();
+            $pageStatus = 'sql_error';
             brevointegration_logger_error('logs.php count query failed', $httpContext + array('sql' => $countSql, 'error' => $errorMessage, 'self' => $selfUrl));
             dol_syslog(__FILE__.'::count_logs '.$errorMessage, LOG_ERR);
-            setEventMessages($langs->trans('ErrorInternalError'), null, 'errors');
+            setEventMessages($langs->trans('ErrorSQL'), null, 'errors');
         } else {
             $countObj = $db->fetch_object($resCount);
             $total = $countObj ? (int) $countObj->total : 0;
@@ -208,18 +217,21 @@ try {
                 $db->free($resCount);
             }
 
+            brevointegration_logger_info('logs.php count query fetched total', $httpContext + array('total' => $total, 'self' => $selfUrl));
+
             $sql = 'SELECT rowid, date_event, method, endpoint, http_code, duration_ms, success, message FROM '.MAIN_DB_PREFIX.'brevo_log';
             $sql .= ' WHERE '.$whereClause;
             $sql .= ' ORDER BY '.$allowedSortfields[$sortfield].' '.$sortorder;
             $sql .= $db->plimit($limit, $offset);
 
-            brevointegration_logger_debug('logs.php select query', $httpContext + array('sql' => $sql, 'limit' => $limit, 'offset' => $offset, 'self' => $selfUrl));
+            brevointegration_logger_info('Executing SQL (select)', $httpContext + array('sql' => $sql, 'limit' => $limit, 'offset' => $offset, 'self' => $selfUrl));
             $resql = $db->query($sql);
             if ($resql === false) {
                 $errorMessage = $db->lasterror();
+                $pageStatus = 'sql_error';
                 brevointegration_logger_error('logs.php select query failed', $httpContext + array('sql' => $sql, 'error' => $errorMessage, 'self' => $selfUrl));
                 dol_syslog(__FILE__.'::select_logs '.$errorMessage, LOG_ERR);
-                setEventMessages($langs->trans('ErrorInternalError'), null, 'errors');
+                setEventMessages($langs->trans('ErrorSQL'), null, 'errors');
             } else {
                 while ($obj = $db->fetch_object($resql)) {
                     $logs[] = array(
@@ -236,6 +248,9 @@ try {
                 if (method_exists($db, 'free')) {
                     $db->free($resql);
                 }
+
+                $logsFetched = count($logs);
+                brevointegration_logger_info('logs.php select query fetched rows', $httpContext + array('fetched' => $logsFetched, 'self' => $selfUrl));
             }
         }
     }
@@ -337,11 +352,10 @@ try {
 
     llxFooter();
     $layoutStarted = false;
-    $db->close();
 
-    brevointegration_logger_info('logs.php completed', $httpContext + array('status' => 'success', 'total' => $total, 'displayed' => count($logs), 'self' => $selfUrl));
 } catch (Throwable $exception) {
-    brevointegration_logger_error('logs.php fatal exception', $httpContext + array('exception' => $exception, 'self' => isset($selfUrl) ? $selfUrl : ''));
+    $pageStatus = 'exception';
+    brevointegration_logger_error('logs.php fatal exception', $httpContext + array('exception' => $exception, 'self' => $selfUrl));
 
     if (!$layoutStarted) {
         llxHeader('', $langs->trans('BrevoLogsTitle'));
@@ -356,8 +370,20 @@ try {
     if ($layoutStarted) {
         llxFooter();
     }
-
+} finally {
     if (isset($db) && method_exists($db, 'close')) {
         $db->close();
     }
+
+    brevointegration_logger_info(
+        $pageStatus === 'success' ? 'logs.php finished normally' : 'logs.php finished with status='.$pageStatus,
+        $httpContext + array(
+            'status' => $pageStatus,
+            'total' => isset($total) ? (int) $total : 0,
+            'displayed' => $logsFetched,
+            'self' => $selfUrl,
+            'user_id' => $currentUserId,
+            'user_login' => $currentUserLogin,
+        )
+    );
 }

--- a/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
@@ -32,7 +32,7 @@ class modBrevointegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.16';
+        $this->version = '1.3.17';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';


### PR DESCRIPTION
## Summary
- extend Brevo admin logs page to journal start/finish events, SQL execution details, and user context in brevo_admin.log
- ensure SQL failures raise explicit Dolibarr "Erreur SQL" messages while tracking final status via a finally block
- bump module version to 1.3.17 and update changelog/bug tracker documentation accordingly

## Testing
- php -l htdocs/custom/brevointegration/admin/logs.php

------
https://chatgpt.com/codex/tasks/task_e_68d831d594488320b334cb77eab55d9d