### PR TITLE
Fix Dolibarr loader fallbacks for Brevo integration pages

### DIFF
--- a/htdocs/custom/brevointegration/CHANGELOG.md
+++ b/htdocs/custom/brevointegration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.3.18] - 2025-10-20
+### Changed
+- Harmonisation du chargement de l'environnement Dolibarr pour supporter les installations du module en racine ou dans `htdocs/custom`.
+
 ## [1.3.17] - 2025-10-19
 ### Changed
 - Ajout d'une journalisation chronologique détaillée sur `admin/logs.php` (démarrage, exécution des requêtes SQL, nombre de lignes récupérées, clôture) dans le fichier `brevo_admin.log`.

--- a/htdocs/custom/brevointegration/admin/logs.php
+++ b/htdocs/custom/brevointegration/admin/logs.php
@@ -8,8 +8,33 @@ declare(strict_types=1);
  * @brief     Administration page to inspect Brevo API logs.
  */
 
-// --- Deterministic loader (more reliable on SaaS/proxied setups)
-require __DIR__.'/../../../main.inc.php';
+// --- Deterministic loader compatible with module installed in htdocs/ or htdocs/custom/
+if (!defined('DOL_DOCUMENT_ROOT')) {
+    $mainIncludeFound = false;
+    $includeCandidates = array(
+        __DIR__.'/../../main.inc.php',
+        __DIR__.'/../../master.inc.php',
+        __DIR__.'/../../../main.inc.php',
+        __DIR__.'/../../../master.inc.php',
+    );
+
+    foreach ($includeCandidates as $includeCandidate) {
+        if (!is_file($includeCandidate)) {
+            continue;
+        }
+
+        require_once $includeCandidate;
+
+        if (defined('DOL_DOCUMENT_ROOT')) {
+            $mainIncludeFound = true;
+            break;
+        }
+    }
+
+    if (!$mainIncludeFound) {
+        throw new RuntimeException('Unable to load Dolibarr main include file.');
+    }
+}
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/list.lib.php';

--- a/htdocs/custom/brevointegration/admin/setup.php
+++ b/htdocs/custom/brevointegration/admin/setup.php
@@ -8,7 +8,32 @@ declare(strict_types=1);
  * @brief     Administration page to configure Brevo API key.
  */
 
-require __DIR__.'/../../../main.inc.php';
+if (!defined('DOL_DOCUMENT_ROOT')) {
+    $mainIncludeFound = false;
+    $includeCandidates = array(
+        __DIR__.'/../../main.inc.php',
+        __DIR__.'/../../master.inc.php',
+        __DIR__.'/../../../main.inc.php',
+        __DIR__.'/../../../master.inc.php',
+    );
+
+    foreach ($includeCandidates as $includeCandidate) {
+        if (!is_file($includeCandidate)) {
+            continue;
+        }
+
+        require_once $includeCandidate;
+
+        if (defined('DOL_DOCUMENT_ROOT')) {
+            $mainIncludeFound = true;
+            break;
+        }
+    }
+
+    if (!$mainIncludeFound) {
+        throw new RuntimeException('Unable to load Dolibarr main include file.');
+    }
+}
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 dol_include_once('/brevointegration/class/BrevoClient.class.php');

--- a/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
+++ b/htdocs/custom/brevointegration/core/modules/modBrevointegration.class.php
@@ -32,7 +32,7 @@ class modBrevointegration extends DolibarrModules
         $this->editor_url = 'https://meditrust.io';
         $this->name = preg_replace('/^mod/i', '', get_class($this));
         $this->description = 'Brevo integration for Dolibarr';
-        $this->version = '1.3.17';
+        $this->version = '1.3.18';
         $this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
         $this->special = 0;
         $this->picto = 'icon-picto-brevo.svg@brevointegration';

--- a/htdocs/custom/brevointegration/lists.php
+++ b/htdocs/custom/brevointegration/lists.php
@@ -8,7 +8,32 @@ declare(strict_types=1);
  * @brief     Page to display Brevo contact lists.
  */
 
-require __DIR__.'/../../main.inc.php';
+if (!defined('DOL_DOCUMENT_ROOT')) {
+    $mainIncludeFound = false;
+    $includeCandidates = array(
+        __DIR__.'/../main.inc.php',
+        __DIR__.'/../master.inc.php',
+        __DIR__.'/../../main.inc.php',
+        __DIR__.'/../../master.inc.php',
+    );
+
+    foreach ($includeCandidates as $includeCandidate) {
+        if (!is_file($includeCandidate)) {
+            continue;
+        }
+
+        require_once $includeCandidate;
+
+        if (defined('DOL_DOCUMENT_ROOT')) {
+            $mainIncludeFound = true;
+            break;
+        }
+    }
+
+    if (!$mainIncludeFound) {
+        throw new RuntimeException('Unable to load Dolibarr main include file.');
+    }
+}
 
 dol_include_once('/brevointegration/class/BrevoClient.class.php');
 


### PR DESCRIPTION
## Summary
- ensure the Brevo admin and list entry points load Dolibarr core whether the module lives in htdocs/ or htdocs/custom/
- surface a clear runtime error if the Dolibarr environment cannot be loaded
- bump the module version to 1.3.18 and document the loader change in the changelog

## Testing
- php -l htdocs/custom/brevointegration/admin/logs.php
- php -l htdocs/custom/brevointegration/admin/setup.php
- php -l htdocs/custom/brevointegration/lists.php

------
https://chatgpt.com/codex/tasks/task_e_68d833669d54832092c9348caad06fbd